### PR TITLE
Unique constraint names oracle

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
 # ShapeChange
 Processing application schemas for geographic information. See the [wiki](https://github.com/ShapeChange/ShapeChange/wiki) for information how to set up the development environment and the [ShapeChange website](http://shapechange.net) for documentation how to use ShapeChange.
+
+## About this fork
+This fork of ShapeChange is created to accommodate changes to ShapeChange that are needed in the Agency for Data Supply and Efficiency and that are not (yet) present in the official repository.

--- a/src/main/java/de/interactive_instruments/ShapeChange/Target/JSON/JsonSchema.java
+++ b/src/main/java/de/interactive_instruments/ShapeChange/Target/JSON/JsonSchema.java
@@ -230,7 +230,10 @@ public class JsonSchema implements Target, MessageSource {
 			write(ctx,"\t"+"\"title\":\""+(s==null||s.isEmpty()?ci.name():s)+"\",");
 			newLine(ctx);
 			String s2 = ci.derivedDocumentation(documentationTemplate, documentationNoValue);
-			if (includeDocumentation && !s2.isEmpty()) {
+			if (ci.globalId() != null) {
+				write(ctx, "\t" + "\"description\":\"" + ci.globalId() + "\",");
+				newLine(ctx);
+			} else if (includeDocumentation && !s2.isEmpty()) {
 				write(ctx,"\t"+"\"description\":\""+escape(s2).trim()+"\",");
 				newLine(ctx);				
 			}
@@ -511,7 +514,10 @@ public class JsonSchema implements Target, MessageSource {
 						write(ctx,"\t\t\t\t\t"+"\"title\":\""+(s==null||s.isEmpty()?propi.name():s)+"\",");
 						newLine(ctx);
 						String s2 = propi.derivedDocumentation(documentationTemplate, documentationNoValue);
-						if (includeDocumentation && !s2.isEmpty()) {
+						if (propi.globalId() != null) {
+							write(ctx, "\t\t\t\t\t" + "\"description\":\"" + propi.globalId() + "\",");
+							newLine(ctx);
+						} else if (includeDocumentation && !s2.isEmpty()) {
 							write(ctx,"\t\t\t\t\t"+"\"description\":\""+escape(s2).trim()+"\",");
 							newLine(ctx);				
 						}

--- a/src/main/java/de/interactive_instruments/ShapeChange/Target/SQL/DatabaseStrategy.java
+++ b/src/main/java/de/interactive_instruments/ShapeChange/Target/SQL/DatabaseStrategy.java
@@ -32,6 +32,7 @@
 package de.interactive_instruments.ShapeChange.Target.SQL;
 
 import java.util.Map;
+import java.util.Set;
 
 import de.interactive_instruments.ShapeChange.MapEntryParamInfos;
 import de.interactive_instruments.ShapeChange.ProcessMapEntry;
@@ -100,13 +101,18 @@ public interface DatabaseStrategy {
 	void validate(Map<String, ProcessMapEntry> mapEntryByType, MapEntryParamInfos mepp);
 
 	/**
+	 * Implementations of this method should add the generated constraint to the set with constraint names.
 	 *
-	 * @param tableName
-	 * @param propertyName
 	 * @return name that is according to the default case of the database
 	 *         system, and that does not exceed the max length for names in the
 	 *         database system
 	 */
-	String createNameCheckConstraint(String tableName, String propertyName);
+	String createNameCheckConstraint(String tableName, String propertyName, Set<String> allConstraintNames);
+	
+	/**
+	 * Implementations of this method should add the generated constraint to the set with constraint names.
+	 * 
+	 */
+	String createNameForeignKey(String tableName, String targetTableName, String fieldName, Set<String> allConstraintNames);
 
 }

--- a/src/main/java/de/interactive_instruments/ShapeChange/Target/SQL/NullDatabaseStrategy.java
+++ b/src/main/java/de/interactive_instruments/ShapeChange/Target/SQL/NullDatabaseStrategy.java
@@ -32,6 +32,7 @@
 package de.interactive_instruments.ShapeChange.Target.SQL;
 
 import java.util.Map;
+import java.util.Set;
 
 import de.interactive_instruments.ShapeChange.MapEntryParamInfos;
 import de.interactive_instruments.ShapeChange.ProcessMapEntry;
@@ -87,7 +88,12 @@ public class NullDatabaseStrategy implements DatabaseStrategy {
 	}
 
 	@Override
-	public String createNameCheckConstraint(String tableName, String propertyName) {
+	public String createNameCheckConstraint(String tableName, String propertyName, Set<String> allConstraintNames) {
+		return "";
+	}
+	
+	@Override
+	public String createNameForeignKey(String tableName, String targetTableName, String fieldName, Set<String> allConstraintNames) {
 		return "";
 	}
 

--- a/src/main/java/de/interactive_instruments/ShapeChange/Target/SQL/PearsonHash.java
+++ b/src/main/java/de/interactive_instruments/ShapeChange/Target/SQL/PearsonHash.java
@@ -1,0 +1,56 @@
+package de.interactive_instruments.ShapeChange.Target.SQL;
+
+import org.apache.commons.lang.StringUtils;
+
+/**
+ * See https://en.wikipedia.org/wiki/Pearson_hashing and the original paper (see the references on Wikipedia) for more information about the functions
+ * in this class.
+ */
+public class PearsonHash {
+
+	private final int[] auxiliaryTable;
+	
+	public PearsonHash() {
+		auxiliaryTable = generateAuxiliaryTable();
+	}
+
+	/**
+	 * 
+	 * @param string string to calculate the Pearson hash of
+	 * @return Pearson hash of the given string
+	 */
+	public int createPearsonHash(String string) {
+		int h = 0;
+		for (int i = 0; i < string.length(); i++) {
+			h = auxiliaryTable[h ^ string.charAt(i)];
+		}
+		return h;
+	}
+	
+	/**
+	 * @param string string to calculate the Pearson hash of
+	 * @return Pearson hash of the given string, padded with zeros so it has a length of 3
+	 */
+	public String createPearsonHashAsLeftPaddedString(String string) {
+		return StringUtils.leftPad(String.valueOf(createPearsonHash(string)), 3, '0');
+	}
+
+	/**
+	 * @return the auxiliary table as presented in the original paper about the Pearson Hash
+	 */
+	private int[] generateAuxiliaryTable() {
+		return new int[] { 1, 87, 49, 12, 176, 178, 102, 166, 121, 193, 6, 84, 249, 230, 44, 163, 14, 197, 213, 181,
+				161, 85, 218, 80, 64, 239, 24, 226, 236, 142, 38, 200, 110, 177, 104, 103, 141, 253, 255, 50, 77, 101,
+				81, 18, 45, 96, 31, 222, 25, 107, 190, 70, 86, 237, 240, 34, 72, 242, 20, 214, 244, 227, 149, 235, 97,
+				234, 57, 22, 60, 250, 82, 175, 208, 5, 127, 199, 111, 62, 135, 248, 174, 169, 211, 58, 66, 154, 106,
+				195, 245, 171, 17, 187, 182, 179, 0, 243, 132, 56, 148, 75, 128, 133, 158, 100, 130, 126, 91, 13, 153,
+				246, 216, 219, 119, 68, 223, 78, 83, 88, 201, 99, 122, 11, 92, 32, 136, 114, 52, 10, 138, 30, 48, 183,
+				156, 35, 61, 26, 143, 74, 251, 94, 129, 162, 63, 152, 170, 7, 115, 167, 241, 206, 3, 150, 55, 59, 151,
+				220, 90, 53, 23, 131, 125, 173, 15, 238, 79, 95, 89, 16, 105, 137, 225, 224, 217, 160, 37, 123, 118, 73,
+				2, 157, 46, 116, 9, 145, 134, 228, 207, 212, 202, 215, 69, 229, 27, 188, 67, 124, 168, 252, 42, 4, 29,
+				108, 21, 247, 19, 205, 39, 203, 233, 40, 186, 147, 198, 192, 155, 33, 164, 191, 98, 204, 165, 180, 117,
+				76, 140, 36, 210, 172, 41, 54, 159, 8, 185, 232, 113, 196, 231, 47, 146, 120, 51, 65, 28, 144, 254, 221,
+				93, 189, 194, 139, 112, 43, 71, 109, 184, 209 };
+	}
+
+}

--- a/src/main/java/de/interactive_instruments/ShapeChange/Target/SQL/PostgreSQLStrategy.java
+++ b/src/main/java/de/interactive_instruments/ShapeChange/Target/SQL/PostgreSQLStrategy.java
@@ -33,6 +33,7 @@ package de.interactive_instruments.ShapeChange.Target.SQL;
 
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import de.interactive_instruments.ShapeChange.MapEntryParamInfos;
 import de.interactive_instruments.ShapeChange.ProcessMapEntry;
@@ -78,13 +79,22 @@ public class PostgreSQLStrategy implements DatabaseStrategy {
 	}
 
 	@Override
-	public String createNameCheckConstraint(String tableName, String propertyName) {
-		return tableName.toLowerCase(Locale.ENGLISH) + "_" + propertyName.toLowerCase(Locale.ENGLISH) + "_chk";
+	public String createNameCheckConstraint(String tableName, String propertyName, Set<String> allConstraintNames) {
+		String name = tableName.toLowerCase(Locale.ENGLISH) + "_" + propertyName.toLowerCase(Locale.ENGLISH) + "_chk";
+		allConstraintNames.add(name);
+		return name;
 	}
 
 	@Override
 	public void validate(Map<String, ProcessMapEntry> mapEntryByType, MapEntryParamInfos mepp) {
 		// nothing specific to check
+	}
+	
+	@Override
+	public String createNameForeignKey(String tableName, String targetTableName, String fieldName, Set<String> allConstraintNames) {
+		String name = "fk_" + tableName + "_" + fieldName;
+		allConstraintNames.add(name);
+		return name;
 	}
 
 }

--- a/src/main/java/de/interactive_instruments/ShapeChange/Target/SQL/SqlDdl.java
+++ b/src/main/java/de/interactive_instruments/ShapeChange/Target/SQL/SqlDdl.java
@@ -346,6 +346,8 @@ public class SqlDdl implements Target, MessageSource {
 	private Set<AssociationInfo> associationsWithAssociativeTable = new HashSet<AssociationInfo>();
 
 	private DatabaseStrategy databaseStrategy;
+	
+	private Set<String> allConstraintNames = new HashSet<String>();
 
 	/**
 	 * @see de.interactive_instruments.ShapeChange.Target.Target#initialise(de.interactive_instruments.ShapeChange.Model.PackageInfo,
@@ -1791,7 +1793,7 @@ public class SqlDdl implements Target, MessageSource {
 
 	/**
 	 * @param name
-	 * @return String with any occurrence of '.' or '-' replaced by '_'.
+	 * @return String with characters that are illegal in database objects replaced by an underscore. Depending on the database, additional normalization can be done.
 	 */
 	private String normalizeName(String name) {
 
@@ -1799,15 +1801,24 @@ public class SqlDdl implements Target, MessageSource {
 			return null;
 		} else {
 			return databaseStrategy
-					.normalizeName(name.replace(".", "_").replace("-", "_"));
+					.normalizeName(replaceIllegalCharacters(name));
 		}
+	}
+
+	/**
+	 * 
+	 * @param string
+	 * @return String with any occurrence of '.' or '-' replaced by '_'.
+	 */
+	private String replaceIllegalCharacters(String string) {
+		return string.replace(".", "_").replace("-", "_");
 	}
 
 	private String createNameCheckConstraint(String tableName, String propertyName) {
 		if (tableName == null || propertyName == null) {
 			return null;
 		}
-		return databaseStrategy.createNameCheckConstraint(tableName.replace(".", "_").replace("-", "_"), propertyName.replace(".", "_").replace("-", "_"));
+		return databaseStrategy.createNameCheckConstraint(replaceIllegalCharacters(tableName), replaceIllegalCharacters(propertyName), allConstraintNames);
 	}
 
 	/**

--- a/src/test/java/de/interactive_instruments/ShapeChange/Target/SQL/OracleStrategyTest.java
+++ b/src/test/java/de/interactive_instruments/ShapeChange/Target/SQL/OracleStrategyTest.java
@@ -1,0 +1,59 @@
+package de.interactive_instruments.ShapeChange.Target.SQL;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.HashSet;
+import java.util.Locale;
+import java.util.Set;
+
+import org.junit.Test;
+
+import de.interactive_instruments.ShapeChange.Options;
+import de.interactive_instruments.ShapeChange.ShapeChangeResult;
+
+public class OracleStrategyTest {
+	
+	private static final int MAX_ORACLE_LENGTH = 30;
+	
+	private OracleStrategy oracleStrategy = new OracleStrategy(new ShapeChangeResult(new Options()));
+	
+	private PearsonHash pearsonHash = new PearsonHash();
+
+	@Test
+	public void testUniqueNameCheckConstraint() {
+		Set<String> allConstraints = new HashSet<String>();
+		String nameCheckConstraint;
+		String[] attributeNames = {"anAttribute1kPPvAZ", "anAttribute1w", "anAttribute1VPHR", "anAttribute1qglh", "anAttribute1DYHuHF", "anAttribute1Rinqr", "anAttribute1uld", "anAttribute1BoDlm", "anAttribute1GlLYmU", "anAttribute1wqIfTUEx"};
+		for (int i = 0; i < attributeNames.length; i++) {
+			// test of the test
+			assertEquals("Combination of 'FeatureType' and the attribute name, as uppercase, should give the same pearson hash", "023", pearsonHash.createPearsonHashAsLeftPaddedString(("FeatureType" + attributeNames[i]).toUpperCase(Locale.ENGLISH)).toUpperCase(Locale.ENGLISH));
+		}
+		nameCheckConstraint = oracleStrategy.createNameCheckConstraint("FeatureType", attributeNames[0], allConstraints);
+		assertEquals(MAX_ORACLE_LENGTH - 1, nameCheckConstraint.length());
+		assertEquals(nameCheckConstraint.toUpperCase(Locale.ENGLISH), nameCheckConstraint);
+		assertEquals(1, allConstraints.size());
+		for (int i = 1; i < attributeNames.length; i++) {
+			nameCheckConstraint = oracleStrategy.createNameCheckConstraint("FeatureType", attributeNames[i], allConstraints);
+			assertEquals(MAX_ORACLE_LENGTH, nameCheckConstraint.length());
+			assertEquals(nameCheckConstraint.toUpperCase(Locale.ENGLISH), nameCheckConstraint);
+			assertEquals(i+1, allConstraints.size());
+			assertTrue(nameCheckConstraint.endsWith(String.valueOf(i-1)));
+		}
+	}
+
+	@Test
+	public void testCreateNameForeignKey() {
+		// short test, does not test all possibilities
+		Set<String> allConstraints = new HashSet<String>();
+		String foreignKeyName = oracleStrategy.createNameForeignKey("FeatureT1", "FeatureT2", "LongField", allConstraints);
+		assertEquals(MAX_ORACLE_LENGTH - 1, foreignKeyName.length());
+		assertEquals(foreignKeyName.toUpperCase(Locale.ENGLISH), foreignKeyName);
+		String foreignKeyName2 = oracleStrategy.createNameForeignKey("FeatureT1", "FeatureT3", "LongField2", allConstraints);
+		assertEquals(MAX_ORACLE_LENGTH - 1, foreignKeyName2.length());
+		assertEquals(foreignKeyName2.toUpperCase(Locale.ENGLISH), foreignKeyName2);
+		assertFalse(foreignKeyName.equals(foreignKeyName2));
+	}
+
+}


### PR DESCRIPTION
This is a proposed solution for issue #44 and for issue #39 .

It involves an update of the generation of constraint names for Oracle, by adding a Pearson hash of the elements currently used for generation the name (table name, column name ...) to the constraint name. This hash is between 000 and 255. This way, constraint names are much less likely to collide, even if the truncated versions of table name and column name are exactly the same. To be 100% sure that constraints names are unique, a digit is added, for the rare cases where the names will collide.

A proposed solution has already been made for #39 in another branch, which is different from the one above, so a discussion and review is definitely needed. I am also not sure in which branch these changes should go, if accepted.

