### PR TITLE
Unique constraint names oracle

### DIFF
--- a/src/main/java/de/interactive_instruments/ShapeChange/Target/SQL/CommonDatabaseObjectNamingScheme.java
+++ b/src/main/java/de/interactive_instruments/ShapeChange/Target/SQL/CommonDatabaseObjectNamingScheme.java
@@ -1,0 +1,12 @@
+package de.interactive_instruments.ShapeChange.Target.SQL;
+
+public abstract class CommonDatabaseObjectNamingScheme implements DatabaseObjectNamingScheme {
+	
+	/**
+	 * @return string with any occurrence of '.' and '-' replaced by '_'.
+	 */
+	protected String replaceIllegalCharacters(String string) {
+		return string.replace(".", "_").replace("-", "_");
+	}
+
+}

--- a/src/main/java/de/interactive_instruments/ShapeChange/Target/SQL/CommonOracleStyleNamingScheme.java
+++ b/src/main/java/de/interactive_instruments/ShapeChange/Target/SQL/CommonOracleStyleNamingScheme.java
@@ -1,0 +1,80 @@
+package de.interactive_instruments.ShapeChange.Target.SQL;
+
+import java.util.Locale;
+import java.util.Set;
+
+import org.apache.commons.lang.StringUtils;
+
+import de.interactive_instruments.ShapeChange.MessageSource;
+import de.interactive_instruments.ShapeChange.ShapeChangeResult;
+
+/**
+ * Creates names that are suitable for Oracle database objects. This includes e.g. creating uppercase names that have a maximum
+ * length of 30.
+ */
+public abstract class CommonOracleStyleNamingScheme extends CommonDatabaseObjectNamingScheme implements MessageSource {
+	
+	protected final int maxLength = 30;
+	
+	protected ShapeChangeResult result;
+
+	public CommonOracleStyleNamingScheme(ShapeChangeResult result) {
+		this.result = result;
+	}
+
+	@Override
+	public String normalizeName(String name) {
+		String upperCaseName = replaceIllegalCharactersAndConvertToUpperCase(name);
+		String normalizedName = StringUtils.substring(upperCaseName, 0, maxLength);
+		if (upperCaseName.length() != normalizedName.length()) {
+			result.addWarning(this, 1, upperCaseName, normalizedName);
+		}
+		return normalizedName;
+	}
+
+	/**
+	 * 
+	 * @param string
+	 * @return an empty string is returned when the argument is null
+	 */
+	protected String replaceIllegalCharactersAndConvertToUpperCase(String string) {
+		return replaceIllegalCharacters(StringUtils.defaultString(string).toUpperCase(Locale.ENGLISH));
+	}
+	
+	/**
+	 * Adds a digit to the given constraint name if that name was already assigned to a constraint. The method calling
+	 * this one needs to ensure that the max length is not exceeded.
+	 */
+	protected String makeConstraintNameUnique(String proposedConstraintName, Set<String> allConstraintNames) {
+		String newProposedConstraintName = proposedConstraintName;
+		if (allConstraintNames.contains(proposedConstraintName)) {
+			// make constraint name unique by adding a digit to it and testing again for uniqueness
+			for (int i = 0; i <= 9; i++) {
+				newProposedConstraintName = proposedConstraintName + i;
+				if (!allConstraintNames.contains(newProposedConstraintName)) {
+					break;
+				}
+			}
+			if (allConstraintNames.contains(newProposedConstraintName)) {
+				result.addWarning(this, 2, newProposedConstraintName);
+			}
+		}
+		return newProposedConstraintName;
+	}
+
+	@Override
+	public String message(int mnr) {
+		// use message numbers between 0 and 99 in this class
+		switch (mnr) {
+		case 0:
+			return "Context: class " + this.getClass().getSimpleName();
+		case 1:
+			return "Name '$1$' is truncated to '$2$'";
+		case 2:
+			return "Constraint name '$1$' will be present more than once, no unique constraint name could be created.";
+		default:
+			return "(Unknown message)";
+		}
+	}
+
+}

--- a/src/main/java/de/interactive_instruments/ShapeChange/Target/SQL/DatabaseObjectNamingScheme.java
+++ b/src/main/java/de/interactive_instruments/ShapeChange/Target/SQL/DatabaseObjectNamingScheme.java
@@ -1,0 +1,29 @@
+package de.interactive_instruments.ShapeChange.Target.SQL;
+
+import java.util.Set;
+
+/**
+ * Specifies ways of assigning names (case, length, composition of different model elements, ...)
+ * to certain database objects (tables, constraints, ...).
+ * 
+ * This interface and its implementing classes are an implementation of the Strategy design pattern.
+ */
+public interface DatabaseObjectNamingScheme {
+
+	/**
+	 * @return name that has a suitable case, length, ...
+	 */
+	String normalizeName(String name);
+
+	/**
+	 * @return suitable name for a check constraint, also taking into account the maximum length of names of database objects and the constraint namespace, if applicable
+	 */
+	String createNameCheckConstraint(String tableName, String propertyName, Set<String> allConstraintNames);
+
+	/**
+	 * @return suitable name for a foreign key, also taking into account the maximum length of names of database objects and the constraint namespace, if applicable
+	 */
+	String createNameForeignKey(String tableName, String targetTableName, String fieldName,
+			Set<String> allConstraintNames);
+
+}

--- a/src/main/java/de/interactive_instruments/ShapeChange/Target/SQL/DatabaseStrategy.java
+++ b/src/main/java/de/interactive_instruments/ShapeChange/Target/SQL/DatabaseStrategy.java
@@ -32,6 +32,7 @@
 package de.interactive_instruments.ShapeChange.Target.SQL;
 
 import java.util.Map;
+import java.util.Set;
 
 import de.interactive_instruments.ShapeChange.MapEntryParamInfos;
 import de.interactive_instruments.ShapeChange.ProcessMapEntry;
@@ -100,13 +101,18 @@ public interface DatabaseStrategy {
 	void validate(Map<String, ProcessMapEntry> mapEntryByType, MapEntryParamInfos mepp);
 
 	/**
+	 * Implementations of this method should add the generated constraint to the set with constraint names.
 	 *
-	 * @param tableName
-	 * @param propertyName
 	 * @return name that is according to the default case of the database
 	 *         system, and that does not exceed the max length for names in the
 	 *         database system
 	 */
-	String createNameCheckConstraint(String tableName, String propertyName);
+	String createNameCheckConstraint(String tableName, String propertyName, Set<String> allConstraintNames);
+	
+	/**
+	 * Implementations of this method should add the generated constraint to the set with constraint names.
+	 * 
+	 */
+	String createNameForeignKey(String tableName, String targetTableName, String fieldName, Set<String> allConstraintNames);
 
 }

--- a/src/main/java/de/interactive_instruments/ShapeChange/Target/SQL/DefaultOracleStyleNamingScheme.java
+++ b/src/main/java/de/interactive_instruments/ShapeChange/Target/SQL/DefaultOracleStyleNamingScheme.java
@@ -1,0 +1,40 @@
+package de.interactive_instruments.ShapeChange.Target.SQL;
+
+import java.util.Set;
+
+import org.apache.commons.lang.StringUtils;
+
+import de.interactive_instruments.ShapeChange.ShapeChangeResult;
+
+/**
+ * Naming scheme to support backwards compatibility.
+ */
+public class DefaultOracleStyleNamingScheme extends CommonOracleStyleNamingScheme {
+
+	public DefaultOracleStyleNamingScheme(ShapeChangeResult result) {
+		super(result);
+	}
+
+	@Override
+	public String createNameCheckConstraint(String tableName, String propertyName, Set<String> allConstraintNames) {
+		String tableNameUpperCase = replaceIllegalCharactersAndConvertToUpperCase(tableName);
+		String propertyNameUpperCase = replaceIllegalCharactersAndConvertToUpperCase(propertyName);
+		
+		String truncatedName = StringUtils.substring(tableNameUpperCase, 0, 13) + "_" + StringUtils.substring(propertyNameUpperCase, 0, 13);
+		String checkConstraintName = truncatedName  + "_CK";
+		return checkConstraintName;
+	}
+
+	@Override
+	public String createNameForeignKey(String tableName, String targetTableName, String fieldName,
+			Set<String> allConstraintNames) {
+		String tableNameUpperCase = replaceIllegalCharactersAndConvertToUpperCase(tableName);
+		String fieldNameUpperCase = replaceIllegalCharactersAndConvertToUpperCase(fieldName);
+		
+		String proposedForeignKeyName = "FK_" + tableNameUpperCase + "_" + fieldNameUpperCase;
+		String foreignKeyName = normalizeName(proposedForeignKeyName); // make sure length is <= 30
+		allConstraintNames.add(foreignKeyName);
+		return foreignKeyName;
+	}
+
+}

--- a/src/main/java/de/interactive_instruments/ShapeChange/Target/SQL/NullDatabaseStrategy.java
+++ b/src/main/java/de/interactive_instruments/ShapeChange/Target/SQL/NullDatabaseStrategy.java
@@ -32,6 +32,7 @@
 package de.interactive_instruments.ShapeChange.Target.SQL;
 
 import java.util.Map;
+import java.util.Set;
 
 import de.interactive_instruments.ShapeChange.MapEntryParamInfos;
 import de.interactive_instruments.ShapeChange.ProcessMapEntry;
@@ -87,7 +88,12 @@ public class NullDatabaseStrategy implements DatabaseStrategy {
 	}
 
 	@Override
-	public String createNameCheckConstraint(String tableName, String propertyName) {
+	public String createNameCheckConstraint(String tableName, String propertyName, Set<String> allConstraintNames) {
+		return "";
+	}
+	
+	@Override
+	public String createNameForeignKey(String tableName, String targetTableName, String fieldName, Set<String> allConstraintNames) {
 		return "";
 	}
 

--- a/src/main/java/de/interactive_instruments/ShapeChange/Target/SQL/NullNamingScheme.java
+++ b/src/main/java/de/interactive_instruments/ShapeChange/Target/SQL/NullNamingScheme.java
@@ -1,0 +1,23 @@
+package de.interactive_instruments.ShapeChange.Target.SQL;
+
+import java.util.Set;
+
+public class NullNamingScheme implements DatabaseObjectNamingScheme {
+
+	@Override
+	public String normalizeName(String name) {
+		return "";
+	}
+
+	@Override
+	public String createNameCheckConstraint(String tableName, String propertyName, Set<String> allConstraintNames) {
+		return "";
+	}
+
+	@Override
+	public String createNameForeignKey(String tableName, String targetTableName, String fieldName,
+			Set<String> allConstraintNames) {
+		return "";
+	}
+
+}

--- a/src/main/java/de/interactive_instruments/ShapeChange/Target/SQL/PearsonHash.java
+++ b/src/main/java/de/interactive_instruments/ShapeChange/Target/SQL/PearsonHash.java
@@ -1,0 +1,56 @@
+package de.interactive_instruments.ShapeChange.Target.SQL;
+
+import org.apache.commons.lang.StringUtils;
+
+/**
+ * See https://en.wikipedia.org/wiki/Pearson_hashing and the original paper (see the references on Wikipedia) for more information about the functions
+ * in this class.
+ */
+public class PearsonHash {
+
+	private final int[] auxiliaryTable;
+	
+	public PearsonHash() {
+		auxiliaryTable = generateAuxiliaryTable();
+	}
+
+	/**
+	 * 
+	 * @param string string to calculate the Pearson hash of
+	 * @return Pearson hash of the given string
+	 */
+	public int createPearsonHash(String string) {
+		int h = 0;
+		for (int i = 0; i < string.length(); i++) {
+			h = auxiliaryTable[h ^ string.charAt(i)];
+		}
+		return h;
+	}
+	
+	/**
+	 * @param string string to calculate the Pearson hash of
+	 * @return Pearson hash of the given string, padded with zeros so it has a length of 3
+	 */
+	public String createPearsonHashAsLeftPaddedString(String string) {
+		return StringUtils.leftPad(String.valueOf(createPearsonHash(string)), 3, '0');
+	}
+
+	/**
+	 * @return the auxiliary table as presented in the original paper about the Pearson Hash
+	 */
+	private int[] generateAuxiliaryTable() {
+		return new int[] { 1, 87, 49, 12, 176, 178, 102, 166, 121, 193, 6, 84, 249, 230, 44, 163, 14, 197, 213, 181,
+				161, 85, 218, 80, 64, 239, 24, 226, 236, 142, 38, 200, 110, 177, 104, 103, 141, 253, 255, 50, 77, 101,
+				81, 18, 45, 96, 31, 222, 25, 107, 190, 70, 86, 237, 240, 34, 72, 242, 20, 214, 244, 227, 149, 235, 97,
+				234, 57, 22, 60, 250, 82, 175, 208, 5, 127, 199, 111, 62, 135, 248, 174, 169, 211, 58, 66, 154, 106,
+				195, 245, 171, 17, 187, 182, 179, 0, 243, 132, 56, 148, 75, 128, 133, 158, 100, 130, 126, 91, 13, 153,
+				246, 216, 219, 119, 68, 223, 78, 83, 88, 201, 99, 122, 11, 92, 32, 136, 114, 52, 10, 138, 30, 48, 183,
+				156, 35, 61, 26, 143, 74, 251, 94, 129, 162, 63, 152, 170, 7, 115, 167, 241, 206, 3, 150, 55, 59, 151,
+				220, 90, 53, 23, 131, 125, 173, 15, 238, 79, 95, 89, 16, 105, 137, 225, 224, 217, 160, 37, 123, 118, 73,
+				2, 157, 46, 116, 9, 145, 134, 228, 207, 212, 202, 215, 69, 229, 27, 188, 67, 124, 168, 252, 42, 4, 29,
+				108, 21, 247, 19, 205, 39, 203, 233, 40, 186, 147, 198, 192, 155, 33, 164, 191, 98, 204, 165, 180, 117,
+				76, 140, 36, 210, 172, 41, 54, 159, 8, 185, 232, 113, 196, 231, 47, 146, 120, 51, 65, 28, 144, 254, 221,
+				93, 189, 194, 139, 112, 43, 71, 109, 184, 209 };
+	}
+
+}

--- a/src/main/java/de/interactive_instruments/ShapeChange/Target/SQL/PearsonHashOracleStyleNamingScheme.java
+++ b/src/main/java/de/interactive_instruments/ShapeChange/Target/SQL/PearsonHashOracleStyleNamingScheme.java
@@ -1,0 +1,68 @@
+package de.interactive_instruments.ShapeChange.Target.SQL;
+
+import java.util.Set;
+
+import org.apache.commons.lang.StringUtils;
+
+import de.interactive_instruments.ShapeChange.ShapeChangeResult;
+
+/**
+ * Uses Pearson hashing to create unique names for constraints.
+ */
+public class PearsonHashOracleStyleNamingScheme extends CommonOracleStyleNamingScheme {
+
+	private PearsonHash pearsonHash = new PearsonHash();
+
+	public PearsonHashOracleStyleNamingScheme(ShapeChangeResult result) {
+		super(result);
+	}
+
+	/**
+	 * Constraints in Oracle are in their own namespace and have the maximum length as the other database objects.
+	 */
+	@Override
+	public String createNameCheckConstraint(String tableName, String propertyName, Set<String> allConstraintNames) {
+		String tableNameUpperCase = replaceIllegalCharactersAndConvertToUpperCase(tableName);
+		String propertyNameUpperCase = replaceIllegalCharactersAndConvertToUpperCase(propertyName);
+		
+		String proposedCheckConstraintNameWithoutAffix = StringUtils.substring(tableNameUpperCase, 0, 11)
+				+ "_"
+				+ StringUtils.substring(propertyNameUpperCase, 0, 11)
+				+ pearsonHash.createPearsonHashAsLeftPaddedString(tableNameUpperCase + propertyNameUpperCase);
+		// TODO support for choice between prefix and suffix (via rule determined in SqlDdl? new naming scheme might be overkill here?)
+		String proposedCheckConstraintName = "CK_" + proposedCheckConstraintNameWithoutAffix;
+		String checkConstraintName = makeConstraintNameUnique(proposedCheckConstraintName, allConstraintNames);
+		allConstraintNames.add(checkConstraintName);
+		return checkConstraintName;
+	}
+
+	@Override
+	public String createNameForeignKey(String tableName, String targetTableName, String fieldName, Set<String> allConstraintNames) {
+		String tableNameUpperCase = replaceIllegalCharactersAndConvertToUpperCase(tableName);
+		String targetTableNameUpperCase = replaceIllegalCharactersAndConvertToUpperCase(targetTableName);
+		String fieldNameUpperCase = replaceIllegalCharactersAndConvertToUpperCase(fieldName);
+		
+		String proposedForeignKeyNameWithoutAffix = StringUtils.substring(tableNameUpperCase, 0, 7)
+			+ "_"
+			+ StringUtils.substring(targetTableNameUpperCase, 0, 7)
+			+ "_"
+			+ StringUtils.substring(fieldNameUpperCase, 0, 7)
+			+ pearsonHash.createPearsonHashAsLeftPaddedString(tableNameUpperCase + targetTableNameUpperCase + fieldNameUpperCase);
+		// TODO support for choice between prefix and suffix (via rule determined in SqlDdl? new naming scheme might be overkill here?)
+		String proposedForeignKeyName = "FK_" + proposedForeignKeyNameWithoutAffix;
+		String foreignKeyName = makeConstraintNameUnique(proposedForeignKeyName, allConstraintNames);
+		allConstraintNames.add(foreignKeyName);
+		return foreignKeyName;
+	}
+	
+	@Override
+	public String message(int mnr) {
+		// use message numbers between 100 and 199 in this class
+		switch (mnr) {
+		default:
+			return super.message(mnr);
+		}
+	}
+
+
+}

--- a/src/main/java/de/interactive_instruments/ShapeChange/Target/SQL/PostgreSQLStrategy.java
+++ b/src/main/java/de/interactive_instruments/ShapeChange/Target/SQL/PostgreSQLStrategy.java
@@ -33,6 +33,7 @@ package de.interactive_instruments.ShapeChange.Target.SQL;
 
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import de.interactive_instruments.ShapeChange.MapEntryParamInfos;
 import de.interactive_instruments.ShapeChange.ProcessMapEntry;
@@ -78,13 +79,22 @@ public class PostgreSQLStrategy implements DatabaseStrategy {
 	}
 
 	@Override
-	public String createNameCheckConstraint(String tableName, String propertyName) {
-		return tableName.toLowerCase(Locale.ENGLISH) + "_" + propertyName.toLowerCase(Locale.ENGLISH) + "_chk";
+	public String createNameCheckConstraint(String tableName, String propertyName, Set<String> allConstraintNames) {
+		String name = tableName.toLowerCase(Locale.ENGLISH) + "_" + propertyName.toLowerCase(Locale.ENGLISH) + "_chk";
+		allConstraintNames.add(name);
+		return name;
 	}
 
 	@Override
 	public void validate(Map<String, ProcessMapEntry> mapEntryByType, MapEntryParamInfos mepp) {
 		// nothing specific to check
+	}
+	
+	@Override
+	public String createNameForeignKey(String tableName, String targetTableName, String fieldName, Set<String> allConstraintNames) {
+		String name = "fk_" + tableName + "_" + fieldName;
+		allConstraintNames.add(name);
+		return name;
 	}
 
 }

--- a/src/main/java/de/interactive_instruments/ShapeChange/Target/SQL/PostgreSQLStrategy.java
+++ b/src/main/java/de/interactive_instruments/ShapeChange/Target/SQL/PostgreSQLStrategy.java
@@ -31,7 +31,6 @@
  */
 package de.interactive_instruments.ShapeChange.Target.SQL;
 
-import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
@@ -39,6 +38,12 @@ import de.interactive_instruments.ShapeChange.MapEntryParamInfos;
 import de.interactive_instruments.ShapeChange.ProcessMapEntry;
 
 public class PostgreSQLStrategy implements DatabaseStrategy {
+
+	private DatabaseObjectNamingScheme namingScheme;
+
+	public PostgreSQLStrategy(DatabaseObjectNamingScheme namingScheme) {
+		this.namingScheme = namingScheme;
+	}
 
 	@Override
 	public String primaryKeyDataType() {
@@ -75,14 +80,12 @@ public class PostgreSQLStrategy implements DatabaseStrategy {
 
 	@Override
 	public String normalizeName(String name) {
-		return name.toLowerCase(Locale.ENGLISH);
+		return namingScheme.normalizeName(name);
 	}
 
 	@Override
 	public String createNameCheckConstraint(String tableName, String propertyName, Set<String> allConstraintNames) {
-		String name = tableName.toLowerCase(Locale.ENGLISH) + "_" + propertyName.toLowerCase(Locale.ENGLISH) + "_chk";
-		allConstraintNames.add(name);
-		return name;
+		return namingScheme.createNameCheckConstraint(tableName, propertyName, allConstraintNames);
 	}
 
 	@Override
@@ -92,9 +95,7 @@ public class PostgreSQLStrategy implements DatabaseStrategy {
 	
 	@Override
 	public String createNameForeignKey(String tableName, String targetTableName, String fieldName, Set<String> allConstraintNames) {
-		String name = "fk_" + tableName + "_" + fieldName;
-		allConstraintNames.add(name);
-		return name;
+		return namingScheme.createNameForeignKey(tableName, targetTableName, fieldName, allConstraintNames);
 	}
 
 }

--- a/src/main/java/de/interactive_instruments/ShapeChange/Target/SQL/PostgreSQLStyleNamingScheme.java
+++ b/src/main/java/de/interactive_instruments/ShapeChange/Target/SQL/PostgreSQLStyleNamingScheme.java
@@ -1,0 +1,39 @@
+package de.interactive_instruments.ShapeChange.Target.SQL;
+
+import java.util.Locale;
+import java.util.Set;
+
+import org.apache.commons.lang.StringUtils;
+
+/**
+ * Creates names that are suitable for PostgreSQL database objects. This includes e.g. creating lowercase names.
+ */
+public class PostgreSQLStyleNamingScheme extends CommonDatabaseObjectNamingScheme {
+	
+	private String replaceIllegalCharactersAndConvertToLowerCase(String string) {
+		return replaceIllegalCharacters(StringUtils.defaultString(string).toLowerCase(Locale.ENGLISH));
+	}
+
+	@Override
+	public String normalizeName(String name) {
+		return replaceIllegalCharactersAndConvertToLowerCase(name);
+	}
+
+	@Override
+	public String createNameCheckConstraint(String tableName, String propertyName, Set<String> allConstraintNames) {
+		String name = replaceIllegalCharactersAndConvertToLowerCase(tableName) + "_" + replaceIllegalCharactersAndConvertToLowerCase(propertyName) + "_chk";
+		// TODO support for choice between prefix and suffix (via rule determined in SqlDdl? new naming scheme might be overkill here?)
+		allConstraintNames.add(name);
+		return name;
+	}
+
+	@Override
+	public String createNameForeignKey(String tableName, String targetTableName, String fieldName,
+			Set<String> allConstraintNames) {
+		String name = "fk_" + replaceIllegalCharactersAndConvertToLowerCase(tableName) + "_" + replaceIllegalCharactersAndConvertToLowerCase(fieldName);
+		// TODO support for choice between prefix and suffix (via rule determined in SqlDdl? new naming scheme might be overkill here?)
+		allConstraintNames.add(name);
+		return name;
+	}
+
+}

--- a/src/main/java/de/interactive_instruments/ShapeChange/Target/SQL/SqlDdl.java
+++ b/src/main/java/de/interactive_instruments/ShapeChange/Target/SQL/SqlDdl.java
@@ -346,6 +346,8 @@ public class SqlDdl implements Target, MessageSource {
 	private Set<AssociationInfo> associationsWithAssociativeTable = new HashSet<AssociationInfo>();
 
 	private DatabaseStrategy databaseStrategy;
+	
+	private Set<String> allConstraintNames = new HashSet<String>();
 
 	/**
 	 * @see de.interactive_instruments.ShapeChange.Target.Target#initialise(de.interactive_instruments.ShapeChange.Model.PackageInfo,
@@ -1791,7 +1793,7 @@ public class SqlDdl implements Target, MessageSource {
 
 	/**
 	 * @param name
-	 * @return String with any occurrence of '.' or '-' replaced by '_'.
+	 * @return String with characters that are illegal in database objects replaced by an underscore. Depending on the database, additional normalization can be done.
 	 */
 	private String normalizeName(String name) {
 
@@ -1799,15 +1801,24 @@ public class SqlDdl implements Target, MessageSource {
 			return null;
 		} else {
 			return databaseStrategy
-					.normalizeName(name.replace(".", "_").replace("-", "_"));
+					.normalizeName(replaceIllegalCharacters(name));
 		}
+	}
+
+	/**
+	 * 
+	 * @param string
+	 * @return String with any occurrence of '.' or '-' replaced by '_'.
+	 */
+	private String replaceIllegalCharacters(String string) {
+		return string.replace(".", "_").replace("-", "_");
 	}
 
 	private String createNameCheckConstraint(String tableName, String propertyName) {
 		if (tableName == null || propertyName == null) {
 			return null;
 		}
-		return databaseStrategy.createNameCheckConstraint(tableName.replace(".", "_").replace("-", "_"), propertyName.replace(".", "_").replace("-", "_"));
+		return databaseStrategy.createNameCheckConstraint(replaceIllegalCharacters(tableName), replaceIllegalCharacters(propertyName), allConstraintNames);
 	}
 
 	/**

--- a/src/main/java/de/interactive_instruments/ShapeChange/Target/SQL/SqlDdl.java
+++ b/src/main/java/de/interactive_instruments/ShapeChange/Target/SQL/SqlDdl.java
@@ -142,6 +142,11 @@ public class SqlDdl implements Target, MessageSource {
 	public static final String PARAM_DATABASE_SYSTEM = "databaseSystem";
 	
 	/**
+	 * Identifier of the naming scheme that will be used for the creation of database object names.
+	 */
+	public static final String PARAM_NAMING_SCHEME = "namingScheme";
+	
+	/**
 	 * Optional changes to the default documentation template and the default strings for descriptors without value
 	 */
 	public static final String PARAM_DOCUMENTATION_TEMPLATE = "documentationTemplate";
@@ -212,6 +217,7 @@ public class SqlDdl implements Target, MessageSource {
 	 * If this rule is enabled derived properties will be ignored.
 	 */
 	public static final String RULE_TGT_SQL_PROP_EXCLUDE_DERIVED = "rule-sql-prop-exclude-derived";
+	
 
 	/* --------------------- */
 	/* --- Tagged Values --- */
@@ -347,6 +353,8 @@ public class SqlDdl implements Target, MessageSource {
 
 	private DatabaseStrategy databaseStrategy;
 	
+	private DatabaseObjectNamingScheme namingScheme;
+	
 	private Set<String> allConstraintNames = new HashSet<String>();
 
 	/**
@@ -396,14 +404,28 @@ public class SqlDdl implements Target, MessageSource {
 		if (pi.matches(RULE_TGT_SQL_ALL_ASSOCIATIVETABLES)) {
 			this.createAssociativeTables = true;
 		}
+		
+		String namingSchemeParam = options.parameter(this.getClass().getName(),
+				PARAM_NAMING_SCHEME);
 
 		String databaseSystem = options.parameter(this.getClass().getName(),
 				PARAM_DATABASE_SYSTEM);
+		
 		if (databaseSystem == null
 				|| "postgresql".equalsIgnoreCase(databaseSystem)) {
-			databaseStrategy = new PostgreSQLStrategy();
+			if (namingSchemeParam == null) {
+				namingScheme = new PostgreSQLStyleNamingScheme();
+			} else {
+				namingScheme = determineNamingSchemeFromParameter(namingSchemeParam);
+			}
+			databaseStrategy = new PostgreSQLStrategy(namingScheme);
 		} else if ("oracle".equalsIgnoreCase(databaseSystem)) {
-			databaseStrategy = new OracleStrategy(result);
+			if (namingSchemeParam == null) {
+				namingScheme = new DefaultOracleStyleNamingScheme(result);
+			} else {
+				namingScheme = determineNamingSchemeFromParameter(namingSchemeParam);
+			}
+			databaseStrategy = new OracleStrategy(namingScheme, result);
 		} else {
 			databaseStrategy = new NullDatabaseStrategy();
 			result.addFatalError(this, 6, databaseSystem);
@@ -519,6 +541,23 @@ public class SqlDdl implements Target, MessageSource {
 
 			validateMapEntryParamInfos(mepp);
 		}
+	}
+	
+	private DatabaseObjectNamingScheme determineNamingSchemeFromParameter(String namingSchemeParam) {
+		DatabaseObjectNamingScheme namingScheme;
+		if ("postgresql".equalsIgnoreCase(namingSchemeParam)) {
+			namingScheme = new PostgreSQLStyleNamingScheme();
+		} else if ("oracleDefault".equalsIgnoreCase(namingSchemeParam)) {
+			namingScheme = new DefaultOracleStyleNamingScheme(result);
+		} else if ("oracleTruncate".equalsIgnoreCase(namingSchemeParam)) {
+			namingScheme = new TruncateOracleStyleNamingScheme(result);
+		} else if ("oraclePearson".equalsIgnoreCase(namingSchemeParam)) {
+			namingScheme = new PearsonHashOracleStyleNamingScheme(result);
+		} else {
+			namingScheme = new NullNamingScheme();
+			result.addWarning(this, 22, namingSchemeParam);
+		}
+		return namingScheme;
 	}
 
 	private void validateMapEntryParamInfos(MapEntryParamInfos mepp2) {
@@ -641,7 +680,7 @@ public class SqlDdl implements Target, MessageSource {
 	public void createForeignKeyDefinition(String className, PropertyInfo pi) {
 
 		String res = "ALTER TABLE " + normalizeName(className)
-				+ " ADD CONSTRAINT " + getForeignKeyIdentifier(pi)
+				+ " ADD CONSTRAINT " + databaseStrategy.createNameForeignKey(pi.inClass().name(), determineTableNameForValueType(pi), pi.name(), allConstraintNames)
 				+ " FOREIGN KEY ("
 				+ normalizeName(pi.name() + identifyForeignKeyColumnSuffix(pi))
 				+ ") REFERENCES " + determineTableNameForValueType(pi) + ";"
@@ -695,7 +734,7 @@ public class SqlDdl implements Target, MessageSource {
 
 		String res = "ALTER TABLE " + normalizeName(tableName)
 				+ " ADD CONSTRAINT "
-				+ getForeignKeyIdentifier(tableName, fieldName)
+				+ databaseStrategy.createNameForeignKey(tableName, targetTableName, fieldName, allConstraintNames)
 				+ " FOREIGN KEY (" + normalizeName(fieldName) + ") REFERENCES "
 				+ normalizeName(targetTableName) + ";" + CRLF;
 
@@ -707,30 +746,6 @@ public class SqlDdl implements Target, MessageSource {
 		}
 
 		this.referenceColumnDefinitionsByTableName.get(tableName).add(res);
-	}
-
-	private String getForeignKeyIdentifier(PropertyInfo pi) {
-
-		return getForeignKeyIdentifier(pi.inClass().name(), pi.name());
-	}
-
-	/**
-	 * @param tableName
-	 * @param fieldName
-	 * @return the normalized identifier for the foreign key
-	 */
-	private String getForeignKeyIdentifier(String tableName, String fieldName) {
-
-		/*
-		 * The following is most often too long, thus we simply use the table
-		 * and field name
-		 */
-		// String res = "fk_" + className + "_" + fieldName + "_to_"
-		// + targetClassName;
-
-		String res = "fk_" + tableName + "_" + fieldName;
-
-		return normalizeName(res);
 	}
 
 	private void generateTableCreationAndAlterStatements(ClassInfo ci) {
@@ -1791,34 +1806,12 @@ public class SqlDdl implements Target, MessageSource {
 		return TargetIdentification.SQLDDL.getId();
 	}
 
-	/**
-	 * @param name
-	 * @return String with characters that are illegal in database objects replaced by an underscore. Depending on the database, additional normalization can be done.
-	 */
 	private String normalizeName(String name) {
-
-		if (name == null) {
-			return null;
-		} else {
-			return databaseStrategy
-					.normalizeName(replaceIllegalCharacters(name));
-		}
-	}
-
-	/**
-	 * 
-	 * @param string
-	 * @return String with any occurrence of '.' or '-' replaced by '_'.
-	 */
-	private String replaceIllegalCharacters(String string) {
-		return string.replace(".", "_").replace("-", "_");
+		return databaseStrategy.normalizeName(name);
 	}
 
 	private String createNameCheckConstraint(String tableName, String propertyName) {
-		if (tableName == null || propertyName == null) {
-			return null;
-		}
-		return databaseStrategy.createNameCheckConstraint(replaceIllegalCharacters(tableName), replaceIllegalCharacters(propertyName), allConstraintNames);
+		return databaseStrategy.createNameCheckConstraint(tableName, propertyName, allConstraintNames);
 	}
 
 	/**
@@ -1881,6 +1874,8 @@ public class SqlDdl implements Target, MessageSource {
 			return "Invalid map entry for type '$1$': value provided for characteristic '$2$' of parameter '$3$' is invalid. Check that the value matches the regular expression: $4$.";
 		case 21:
 			return "?? The type '$1$' was not found in the schema(s) selected for processing or in map entries. It will be mapped to 'unknown'.";
+		case 22:
+			return "Unknown naming scheme '$1$'";
 		case 100:
 			return "Context: property '$1$' in class '$2$'.";
 		default:

--- a/src/main/java/de/interactive_instruments/ShapeChange/Target/SQL/TruncateOracleStyleNamingScheme.java
+++ b/src/main/java/de/interactive_instruments/ShapeChange/Target/SQL/TruncateOracleStyleNamingScheme.java
@@ -1,0 +1,62 @@
+package de.interactive_instruments.ShapeChange.Target.SQL;
+
+import java.util.Set;
+
+import org.apache.commons.lang.StringUtils;
+
+import de.interactive_instruments.ShapeChange.ShapeChangeResult;
+
+/**
+ * Uses simple truncation to create constraint names that do not exceed the maximum length in Oracle for database objects and makes
+ * sure that constraint names are unique by adding an index if needed.
+ */
+public class TruncateOracleStyleNamingScheme extends CommonOracleStyleNamingScheme {
+
+	public TruncateOracleStyleNamingScheme(ShapeChangeResult result) {
+		super(result);
+	}
+
+	@Override
+	public String createNameCheckConstraint(String tableName, String propertyName, Set<String> allConstraintNames) {
+		String tableNameUpperCase = replaceIllegalCharactersAndConvertToUpperCase(tableName);
+		String propertyNameUpperCase = replaceIllegalCharactersAndConvertToUpperCase(propertyName);
+		
+		String truncatedName = StringUtils.substring(tableNameUpperCase, 0, 13) + StringUtils.substring(propertyNameUpperCase, 0, 13);
+		String proposedCheckConstraintName = truncatedName  + "_CK";
+		String checkConstraintName = makeConstraintNameUnique(proposedCheckConstraintName, allConstraintNames);
+		allConstraintNames.add(checkConstraintName);
+		return checkConstraintName;
+	}
+
+	/**
+	 * Generates foreign key identifiers as follows:
+	 * "FK_" + tableNameForFK + "" + targetTableNameForFK + "" + fieldNameForFK + count
+	 * where:
+	 * <ul><li>tableNameForFK is the name of the table that contains the field with the foreign key, clipped to the first eight characters</li>
+	 * <li>targetTableNameForFK is the name of the table that the field with foreign key references, clipped to the first eight characters</li>
+	 * <li>fieldNameForFK is the name of the field that contains the foreign key, clipped to the first eight characters</li>
+	 * <li>count is the number of times the foreign key identifier has been assigned; it ranges from 0-9 and can also be omitted, thus supporting eleven unambiguous uses of the foreign key identifier</li></ul>
+	 */
+	@Override
+	public String createNameForeignKey(String tableName, String targetTableName, String fieldName,
+			Set<String> allConstraintNames) {
+		String tableNameUpperCase = replaceIllegalCharactersAndConvertToUpperCase(tableName);
+		String targetTableNameUpperCase = replaceIllegalCharactersAndConvertToUpperCase(targetTableName);
+		String fieldNameUpperCase = replaceIllegalCharactersAndConvertToUpperCase(fieldName);
+		
+		String proposedForeignKeyName = "FK_" + StringUtils.substring(tableNameUpperCase, 0, 8) + StringUtils.substring(targetTableNameUpperCase, 0, 8) + StringUtils.substring(fieldNameUpperCase, 0, 8);
+		String foreignKeyName = makeConstraintNameUnique(proposedForeignKeyName, allConstraintNames);
+		allConstraintNames.add(foreignKeyName);
+		return foreignKeyName;
+	}
+	
+	@Override
+	public String message(int mnr) {
+		// use message numbers between 200 and 299 in this class
+		switch (mnr) {
+		default:
+			return super.message(mnr);
+		}
+	}
+
+}

--- a/src/test/java/de/interactive_instruments/ShapeChange/Target/SQL/DefaultOracleStyleNamingSchemeTest.java
+++ b/src/test/java/de/interactive_instruments/ShapeChange/Target/SQL/DefaultOracleStyleNamingSchemeTest.java
@@ -1,0 +1,42 @@
+package de.interactive_instruments.ShapeChange.Target.SQL;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.Test;
+
+import de.interactive_instruments.ShapeChange.Options;
+import de.interactive_instruments.ShapeChange.ShapeChangeResult;
+
+public class DefaultOracleStyleNamingSchemeTest {
+	
+	private DefaultOracleStyleNamingScheme defaultOracleStyleNamingScheme;
+	
+	public DefaultOracleStyleNamingSchemeTest() {
+		ShapeChangeResult result = new ShapeChangeResult(new Options());
+		defaultOracleStyleNamingScheme = new DefaultOracleStyleNamingScheme(result);
+	}
+
+	@Test
+	public void testCreateNameCheckConstraint() {
+		Set<String> allConstraints = new HashSet<String>();
+		String checkConstraintName = defaultOracleStyleNamingScheme.createNameCheckConstraint("FeatureWithLongName", "PropertyOfFeature1", allConstraints);
+		assertEquals("FEATUREWITHLO_PROPERTYOFFEA_CK", checkConstraintName);
+		String checkConstraintName2 = defaultOracleStyleNamingScheme.createNameCheckConstraint("FeatureWithLongName", "PropertyOfFeature2", allConstraints);
+		assertEquals("FEATUREWITHLO_PROPERTYOFFEA_CK", checkConstraintName2);
+	}
+
+	@Test
+	public void testCreateNameForeignKey() {
+		Set<String> allConstraints = new HashSet<String>();
+		String foreignKeyName = defaultOracleStyleNamingScheme.createNameForeignKey("FeatureT1", "FeatureT2", "LongField", allConstraints);
+		assertEquals("FK_FEATURET1_LONGFIELD", foreignKeyName);
+		String foreignKeyName2 = defaultOracleStyleNamingScheme.createNameForeignKey("FeatureT1", "FeatureT3", "LongField", allConstraints);
+		assertEquals("FK_FEATURET1_LONGFIELD", foreignKeyName2);
+		String foreignKeyName3 = defaultOracleStyleNamingScheme.createNameForeignKey("FeatureT1", "FeatureT4", "VeryVeryVeryLongField", allConstraints);
+		assertEquals("FK_FEATURET1_VERYVERYVERYLONGF", foreignKeyName3);
+	}
+
+}

--- a/src/test/java/de/interactive_instruments/ShapeChange/Target/SQL/OracleStrategyTest.java
+++ b/src/test/java/de/interactive_instruments/ShapeChange/Target/SQL/OracleStrategyTest.java
@@ -1,0 +1,59 @@
+package de.interactive_instruments.ShapeChange.Target.SQL;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.HashSet;
+import java.util.Locale;
+import java.util.Set;
+
+import org.junit.Test;
+
+import de.interactive_instruments.ShapeChange.Options;
+import de.interactive_instruments.ShapeChange.ShapeChangeResult;
+
+public class OracleStrategyTest {
+	
+	private static final int MAX_ORACLE_LENGTH = 30;
+	
+	private OracleStrategy oracleStrategy = new OracleStrategy(new ShapeChangeResult(new Options()));
+	
+	private PearsonHash pearsonHash = new PearsonHash();
+
+	@Test
+	public void testUniqueNameCheckConstraint() {
+		Set<String> allConstraints = new HashSet<String>();
+		String nameCheckConstraint;
+		String[] attributeNames = {"anAttribute1kPPvAZ", "anAttribute1w", "anAttribute1VPHR", "anAttribute1qglh", "anAttribute1DYHuHF", "anAttribute1Rinqr", "anAttribute1uld", "anAttribute1BoDlm", "anAttribute1GlLYmU", "anAttribute1wqIfTUEx"};
+		for (int i = 0; i < attributeNames.length; i++) {
+			// test of the test
+			assertEquals("Combination of 'FeatureType' and the attribute name, as uppercase, should give the same pearson hash", "023", pearsonHash.createPearsonHashAsLeftPaddedString(("FeatureType" + attributeNames[i]).toUpperCase(Locale.ENGLISH)).toUpperCase(Locale.ENGLISH));
+		}
+		nameCheckConstraint = oracleStrategy.createNameCheckConstraint("FeatureType", attributeNames[0], allConstraints);
+		assertEquals(MAX_ORACLE_LENGTH - 1, nameCheckConstraint.length());
+		assertEquals(nameCheckConstraint.toUpperCase(Locale.ENGLISH), nameCheckConstraint);
+		assertEquals(1, allConstraints.size());
+		for (int i = 1; i < attributeNames.length; i++) {
+			nameCheckConstraint = oracleStrategy.createNameCheckConstraint("FeatureType", attributeNames[i], allConstraints);
+			assertEquals(MAX_ORACLE_LENGTH, nameCheckConstraint.length());
+			assertEquals(nameCheckConstraint.toUpperCase(Locale.ENGLISH), nameCheckConstraint);
+			assertEquals(i+1, allConstraints.size());
+			assertTrue(nameCheckConstraint.endsWith(String.valueOf(i-1)));
+		}
+	}
+
+	@Test
+	public void testCreateNameForeignKey() {
+		// short test, does not test all possibilities
+		Set<String> allConstraints = new HashSet<String>();
+		String foreignKeyName = oracleStrategy.createNameForeignKey("FeatureT1", "FeatureT2", "LongField", allConstraints);
+		assertEquals(MAX_ORACLE_LENGTH - 1, foreignKeyName.length());
+		assertEquals(foreignKeyName.toUpperCase(Locale.ENGLISH), foreignKeyName);
+		String foreignKeyName2 = oracleStrategy.createNameForeignKey("FeatureT1", "FeatureT3", "LongField2", allConstraints);
+		assertEquals(MAX_ORACLE_LENGTH - 1, foreignKeyName2.length());
+		assertEquals(foreignKeyName2.toUpperCase(Locale.ENGLISH), foreignKeyName2);
+		assertFalse(foreignKeyName.equals(foreignKeyName2));
+	}
+
+}

--- a/src/test/java/de/interactive_instruments/ShapeChange/Target/SQL/PearsonHashOracleStyleNamingSchemeTest.java
+++ b/src/test/java/de/interactive_instruments/ShapeChange/Target/SQL/PearsonHashOracleStyleNamingSchemeTest.java
@@ -13,16 +13,21 @@ import org.junit.Test;
 import de.interactive_instruments.ShapeChange.Options;
 import de.interactive_instruments.ShapeChange.ShapeChangeResult;
 
-public class OracleStrategyTest {
+public class PearsonHashOracleStyleNamingSchemeTest {
 	
 	private static final int MAX_ORACLE_LENGTH = 30;
 	
-	private OracleStrategy oracleStrategy = new OracleStrategy(new ShapeChangeResult(new Options()));
+	private PearsonHashOracleStyleNamingScheme pearsonHashOracleStyleNamingScheme;
 	
 	private PearsonHash pearsonHash = new PearsonHash();
+	
+	public PearsonHashOracleStyleNamingSchemeTest() {
+		ShapeChangeResult result = new ShapeChangeResult(new Options());
+		pearsonHashOracleStyleNamingScheme = new PearsonHashOracleStyleNamingScheme(result);
+	}
 
 	@Test
-	public void testUniqueNameCheckConstraint() {
+	public void testCreateNameCheckConstraint() {
 		Set<String> allConstraints = new HashSet<String>();
 		String nameCheckConstraint;
 		String[] attributeNames = {"anAttribute1kPPvAZ", "anAttribute1w", "anAttribute1VPHR", "anAttribute1qglh", "anAttribute1DYHuHF", "anAttribute1Rinqr", "anAttribute1uld", "anAttribute1BoDlm", "anAttribute1GlLYmU", "anAttribute1wqIfTUEx"};
@@ -30,12 +35,12 @@ public class OracleStrategyTest {
 			// test of the test
 			assertEquals("Combination of 'FeatureType' and the attribute name, as uppercase, should give the same pearson hash", "023", pearsonHash.createPearsonHashAsLeftPaddedString(("FeatureType" + attributeNames[i]).toUpperCase(Locale.ENGLISH)).toUpperCase(Locale.ENGLISH));
 		}
-		nameCheckConstraint = oracleStrategy.createNameCheckConstraint("FeatureType", attributeNames[0], allConstraints);
+		nameCheckConstraint = pearsonHashOracleStyleNamingScheme.createNameCheckConstraint("FeatureType", attributeNames[0], allConstraints);
 		assertEquals(MAX_ORACLE_LENGTH - 1, nameCheckConstraint.length());
 		assertEquals(nameCheckConstraint.toUpperCase(Locale.ENGLISH), nameCheckConstraint);
 		assertEquals(1, allConstraints.size());
 		for (int i = 1; i < attributeNames.length; i++) {
-			nameCheckConstraint = oracleStrategy.createNameCheckConstraint("FeatureType", attributeNames[i], allConstraints);
+			nameCheckConstraint = pearsonHashOracleStyleNamingScheme.createNameCheckConstraint("FeatureType", attributeNames[i], allConstraints);
 			assertEquals(MAX_ORACLE_LENGTH, nameCheckConstraint.length());
 			assertEquals(nameCheckConstraint.toUpperCase(Locale.ENGLISH), nameCheckConstraint);
 			assertEquals(i+1, allConstraints.size());
@@ -47,10 +52,10 @@ public class OracleStrategyTest {
 	public void testCreateNameForeignKey() {
 		// short test, does not test all possibilities
 		Set<String> allConstraints = new HashSet<String>();
-		String foreignKeyName = oracleStrategy.createNameForeignKey("FeatureT1", "FeatureT2", "LongField", allConstraints);
+		String foreignKeyName = pearsonHashOracleStyleNamingScheme.createNameForeignKey("FeatureT1", "FeatureT2", "LongField", allConstraints);
 		assertEquals(MAX_ORACLE_LENGTH - 1, foreignKeyName.length());
 		assertEquals(foreignKeyName.toUpperCase(Locale.ENGLISH), foreignKeyName);
-		String foreignKeyName2 = oracleStrategy.createNameForeignKey("FeatureT1", "FeatureT3", "LongField2", allConstraints);
+		String foreignKeyName2 = pearsonHashOracleStyleNamingScheme.createNameForeignKey("FeatureT1", "FeatureT3", "LongField2", allConstraints);
 		assertEquals(MAX_ORACLE_LENGTH - 1, foreignKeyName2.length());
 		assertEquals(foreignKeyName2.toUpperCase(Locale.ENGLISH), foreignKeyName2);
 		assertFalse(foreignKeyName.equals(foreignKeyName2));

--- a/src/test/java/de/interactive_instruments/ShapeChange/Target/SQL/TruncateOracleStyleNamingSchemeTest.java
+++ b/src/test/java/de/interactive_instruments/ShapeChange/Target/SQL/TruncateOracleStyleNamingSchemeTest.java
@@ -1,0 +1,42 @@
+package de.interactive_instruments.ShapeChange.Target.SQL;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.Test;
+
+import de.interactive_instruments.ShapeChange.Options;
+import de.interactive_instruments.ShapeChange.ShapeChangeResult;
+
+public class TruncateOracleStyleNamingSchemeTest {
+	
+	private TruncateOracleStyleNamingScheme truncateOracleStyleNamingScheme;
+	
+	public TruncateOracleStyleNamingSchemeTest() {
+		ShapeChangeResult result = new ShapeChangeResult(new Options());
+		truncateOracleStyleNamingScheme = new TruncateOracleStyleNamingScheme(result);
+	}
+
+	@Test
+	public void testCreateNameCheckConstraint() {
+		Set<String> allConstraints = new HashSet<String>();
+		String checkConstraintName = truncateOracleStyleNamingScheme.createNameCheckConstraint("FeatureWithLongName", "PropertyOfFeature1", allConstraints);
+		assertEquals("FEATUREWITHLOPROPERTYOFFEA_CK", checkConstraintName);
+		String checkConstraintName2 = truncateOracleStyleNamingScheme.createNameCheckConstraint("FeatureWithLongName", "PropertyOfFeature2", allConstraints);
+		assertEquals("FEATUREWITHLOPROPERTYOFFEA_CK0", checkConstraintName2);
+	}
+
+	@Test
+	public void testCreateNameForeignKey() {
+		Set<String> allConstraints = new HashSet<String>();
+		String foreignKeyName = truncateOracleStyleNamingScheme.createNameForeignKey("FeatureT1", "FeatureT2", "LongField", allConstraints);
+		assertEquals("FK_FEATURETFEATURETLONGFIEL", foreignKeyName);
+		String foreignKeyName2 = truncateOracleStyleNamingScheme.createNameForeignKey("FeatureT1", "FeatureT3", "LongField", allConstraints);
+		assertEquals("FK_FEATURETFEATURETLONGFIEL0", foreignKeyName2);
+		String foreignKeyName3 = truncateOracleStyleNamingScheme.createNameForeignKey("FeatureT1", "FeatureT4", "LongField", allConstraints);
+		assertEquals("FK_FEATURETFEATURETLONGFIEL1", foreignKeyName3);
+	}
+
+}


### PR DESCRIPTION
This is a possible solution for issue #44 and for issue #39 .

It involves an update of the generation of constraint names for Oracle, by adding a Pearson hash of the elements currently used for generation the name (table name, column name ...) to the constraint name. This hash is between 000 and 255. This way, constraint names are much less likely to collide, even if the truncated versions of table name and column name are exactly the same. To be 100% sure that constraints names are unique, a digit is added, for the rare cases where the names will collide.

Another solution has already been made for #39 in another branch, which is different from the one above, so a discussion and review is needed.