### PR TITLE
Split class BasicTest into multiple test classes

### DIFF
--- a/src/test/java/de/interactive_instruments/ShapeChange/ApplicationSchemaMetadataTest.java
+++ b/src/test/java/de/interactive_instruments/ShapeChange/ApplicationSchemaMetadataTest.java
@@ -1,0 +1,17 @@
+package de.interactive_instruments.ShapeChange;
+
+import org.junit.Test;
+
+public class ApplicationSchemaMetadataTest extends WindowsBasicTest {
+	
+	@Test
+	public void testApplicationSchemaMetadataDerivation() {
+		/*
+		 * Test derivation of application schema metadata.
+		 */
+		multiTest("src/test/resources/config/testEA_schema_metadata.xml",
+				new String[] { "xml" }, "testResults/schema_metadata/INPUT",
+				"src/test/resources/reference/schema_metadata/INPUT");
+	}
+
+}

--- a/src/test/java/de/interactive_instruments/ShapeChange/AssociationClassMapperTest.java
+++ b/src/test/java/de/interactive_instruments/ShapeChange/AssociationClassMapperTest.java
@@ -1,0 +1,19 @@
+package de.interactive_instruments.ShapeChange;
+
+import org.junit.Test;
+
+public class AssociationClassMapperTest extends WindowsBasicTest {
+	
+	@Test
+	public void testGML33BasedTransformationOfAssociationClasses() {
+		/*
+		 * Test the GML 3.3 based transformation of association classes.
+		 */
+		multiTest(
+				"src/test/resources/config/testEA_associationClassMapper.xml",
+				new String[] { "xsd" },
+				"testResults/associationClassTransform/associationClassMapper",
+				"src/test/resources/reference/associationClassTransform/associationClassMapper");
+	}
+
+}

--- a/src/test/java/de/interactive_instruments/ShapeChange/AttributeCreatorTest.java
+++ b/src/test/java/de/interactive_instruments/ShapeChange/AttributeCreatorTest.java
@@ -1,0 +1,18 @@
+package de.interactive_instruments.ShapeChange;
+
+import org.junit.Test;
+
+public class AttributeCreatorTest extends WindowsBasicTest {
+	
+	@Test
+	public void testAttributeCreation() {
+		/*
+		 * Attribute creation transformer
+		 */
+		multiTest("src/test/resources/config/testEA_attributeCreation.xml",
+				new String[] { "xsd" },
+				"testResults/attribute_creation/xsd",
+				"src/test/resources/reference/xsd/attributeCreation");
+	}
+
+}

--- a/src/test/java/de/interactive_instruments/ShapeChange/BasicTest.java
+++ b/src/test/java/de/interactive_instruments/ShapeChange/BasicTest.java
@@ -32,7 +32,8 @@
 
 package de.interactive_instruments.ShapeChange;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.io.BufferedReader;
 import java.io.ByteArrayOutputStream;
@@ -45,7 +46,6 @@ import java.io.InputStreamReader;
 import java.io.Reader;
 import java.io.StringWriter;
 import java.io.Writer;
-import java.net.URL;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
@@ -58,7 +58,6 @@ import javax.xml.transform.stream.StreamSource;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
-import org.apache.commons.lang.SystemUtils;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.riot.RDFDataMgr;
@@ -72,12 +71,11 @@ import org.custommonkey.xmlunit.HTMLDocumentBuilder;
 import org.custommonkey.xmlunit.TolerantSaxDocumentBuilder;
 import org.custommonkey.xmlunit.XMLUnit;
 import org.custommonkey.xmlunit.jaxp13.Validator;
-import org.junit.Test;
+import org.junit.Before;
 import org.w3c.dom.Document;
 import org.xml.sax.SAXParseException;
 
 import de.interactive_instruments.ShapeChange.Util.ZipHandler;
-import de.interactive_instruments.ShapeChange.TestInstance;
 
 /**
  * Basic unit test for ShapeChange
@@ -89,474 +87,31 @@ import de.interactive_instruments.ShapeChange.TestInstance;
 public class BasicTest {
 
 	boolean testTime = false;
+	
+	/*
+	 * Remaining comments:
+	 */
+	
+	/*
+	 * A simple model to test the creation of a docx feature catalogue
+	 * that includes UML diagrams
+	 */
+	// TODO image file names and sizes not stable
+	// docxTest("src/test/resources/config/testEA_Docx_FC_with_images.xml",
+	// new String[]{"test_featurecatalog_with_images"},
+	// "testResults/docx_with_images/myInputId",
+	// "src/test/resources/reference/docx");
 
-	@Test
-	public void test() {
-		initialise();
+	// TODO add INSPIRE, OKSTRA, no GML, more Schematron tests
 
-		/*
-		 * Invoke without parameters, if we are connected
-		 */
-		String[] xsdTest = { "test" };
-		try {
-			URL url = new URL(
-					"http://shapechange.net/resources/config/minimal.xml");
-			InputStream configStream = url.openStream();
-			if (configStream != null) {
-				xsdTest(null, xsdTest, null, ".",
-						"src/test/resources/reference/xsd");
-			}
-		} catch (Exception e) {
-		}
-
-		/*
-		 * Process the XMI 1.0 test model
-		 */
-		xsdTest("src/test/resources/config/testXMI.xml", xsdTest, null,
-				"testResults/xmi/INPUT", "src/test/resources/reference/xsd");
-
-		/*
-		 * On Windows process also the EA test models
-		 */
-		if (SystemUtils.IS_OS_WINDOWS) {
-
-			/*
-			 * First the same test model as the XMI 1.0 test model
-			 */
-			xsdTest("src/test/resources/config/testEA.xml", xsdTest, null,
-					"testResults/ea/INPUT", "src/test/resources/reference/xsd");
-
-			/*
-			 * Now with some replacement values
-			 */
-			HashMap<String, String> replace = new HashMap<String, String>();
-			replace.put("$eap$", "src/test/resources/test.eap");
-			replace.put("$log$", "testResults/ea/log.xml");
-			replace.put("$out$", "testResults/ea");
-			xsdTest("src/test/resources/config/testEA_x.xml", xsdTest, null,
-					replace, "testResults/ea/INPUT",
-					"src/test/resources/reference/xsd");
-
-			/*
-			 * Test property options: ordered, uniqueness and inline/byReference
-			 */
-			multiTest("src/test/resources/config/testEA_prop.xml",
-					new String[] { "xsd", "xml", "html" },
-					"testResults/ea/prop/INPUT",
-					"src/test/resources/reference/prop");
-
-			/*
-			 * Test multiple tagged values and stereotypes
-			 */
-			HashMap<String, String> replace2 = new HashMap<String, String>();
-			replace2.put("$tvimpl$", "");
-			replace2.put("$logout$",
-					"testResults/multipleTaggedValuesAndStereotypes/tv_map_impl/log.xml");
-			replace2.put("$xsdout$",
-					"testResults/multipleTaggedValuesAndStereotypes/tv_map_impl");
-			xsdTest("src/test/resources/config/testEA_multipleTaggedValuesAndStereotypes.xml",
-					new String[] { "multTvAndSt" }, null, replace2,
-					"testResults/multipleTaggedValuesAndStereotypes/tv_map_impl/INPUT",
-					"src/test/resources/reference/xsd/multipleTaggedValuesAndStereotypes/INPUT");
-
-			/*
-			 * Test multiple tagged values and stereotypes - with array
-			 * implementation for tagged values.
-			 */
-			replace2 = new HashMap<String, String>();
-			replace2.put("$tvimpl$", "array");
-			replace2.put("$logout$",
-					"testResults/multipleTaggedValuesAndStereotypes/tv_array_impl/log.xml");
-			replace2.put("$xsdout$",
-					"testResults/multipleTaggedValuesAndStereotypes/tv_array_impl");
-			xsdTest("src/test/resources/config/testEA_multipleTaggedValuesAndStereotypes.xml",
-					new String[] { "multTvAndSt" }, null, replace2,
-					"testResults/multipleTaggedValuesAndStereotypes/tv_array_impl/INPUT",
-					"src/test/resources/reference/xsd/multipleTaggedValuesAndStereotypes/INPUT");
-
-			/*
-			 * Test the descriptor functionality
-			 */
-			multiTest("src/test/resources/config/testEA_descriptors_fc_en.xml",
-					new String[] { "xml", "html" },
-					"testResults/html/descriptors/INPUT",
-					"src/test/resources/reference/html/descriptors");
-
-			multiTest("src/test/resources/config/testEA_descriptors_fc_de.xml",
-					new String[] { "xml", "html" },
-					"testResults/html/descriptors/INPUT",
-					"src/test/resources/reference/html/descriptors");
-
-			multiTest(
-					"src/test/resources/config/testEA_descriptors_inspire.xml",
-					new String[] { "xml", "html" },
-					"testResults/html/descriptors/INPUT",
-					"src/test/resources/reference/html/descriptors");
-
-			multiTest("src/test/resources/config/testEA_descriptors_aaa.xml",
-					new String[] { "xml", "html" },
-					"testResults/html/descriptors/INPUT",
-					"src/test/resources/reference/html/descriptors");
-
-			multiTest("src/test/resources/config/testEA_descriptors_bbr.xml",
-					new String[] { "xml", "html" },
-					"testResults/html/descriptors/INPUT",
-					"src/test/resources/reference/html/descriptors");
-
-			/*
-			 * Test rule-xsd-cls-codelist-constraints-codeAbsenceInModelAllowed.
-			 */
-			multiTest("src/test/resources/config/testEA_codeAbsenceInModel.xml",
-					new String[] { "xml" },
-					"testResults/codeAbsenceInModel/input",
-					"src/test/resources/reference/xsd/codeAbsenceInModel/input");
-
-			/*
-			 * Test derivation of application schema metadata.
-			 */
-			multiTest("src/test/resources/config/testEA_schema_metadata.xml",
-					new String[] { "xml" }, "testResults/schema_metadata/INPUT",
-					"src/test/resources/reference/schema_metadata/INPUT");
-
-			/*
-			 * Test creation of an HTML feature catalogue with
-			 * inheritedProperties=true and noAlphabeticSortingForProperties =
-			 * true
-			 */
-			multiTest(
-					"src/test/resources/config/testEA_fc_inheritedProperties.xml",
-					new String[] { "xml", "html" },
-					"testResults/html/inheritedProperties/INPUT",
-					"src/test/resources/reference/html/inheritedProperties/INPUT");
-
-			/*
-			 * Test derivation of application schema differences (output as
-			 * single page HTML feature catalogue).
-			 */
-			multiTest("src/test/resources/config/testEA_model_diff.xml",
-					new String[] { "xml", "html" },
-					"testResults/html/diff/INPUT",
-					"src/test/resources/reference/html/diff/INPUT");
-
-			/*
-			 * SQL - basic text
-			 */
-			multiTest("src/test/resources/config/testEA_sql.xml",
-					new String[] { "sql" }, "testResults/sql/basic",
-					"src/test/resources/reference/sql/basic");
-
-			/*
-			 * SQL - associative tables tests
-			 */
-			multiTest(
-					"src/test/resources/config/testEA_sqlAssociativeTables.xml",
-					new String[] { "sql" }, "testResults/sql/associativeTables",
-					"src/test/resources/reference/sql/associativeTables");
-
-			/*
-			 * SQL - geometry parameters test
-			 */
-			multiTest(
-					"src/test/resources/config/testEA_sqlGeometryParameters.xml",
-					new String[] { "sql" },
-					"testResults/sql/geometryParameters",
-					"src/test/resources/reference/sql/geometryParameters");
-
-			/*
-			 * Test XML Schema creation for Application Schema with multiple
-			 * packages that shall be output as individual xsd files.
-			 */
-			multiTest("src/test/resources/config/testEA_packageIncludes.xml",
-					new String[] { "xsd" }, "testResults/xsd/packageIncludes",
-					"src/test/resources/reference/xsd/packageIncludes");
-
-			/*
-			 * Test XML Schema creation for two Application Schema, with
-			 * identity transformation.
-			 */
-			multiTest("src/test/resources/config/testEA_MultipleAppSchema.xml",
-					new String[] { "xsd" }, "testResults/xsd/multiAppSchema",
-					"src/test/resources/reference/xsd/multiAppSchema");
-
-			/*
-			 * A simple model to test the creation of a single-file html feature
-			 * catalogue
-			 */
-			htmlTest("src/test/resources/config/testEA_Html.xml",
-					new String[] { "test" }, "testResults/html/INPUT",
-					"src/test/resources/reference/html");
-
-			/*
-			 * A simple model to test the localization functionality
-			 */
-			htmlTest("src/test/resources/config/testEA_HtmlLocalization.xml",
-					new String[] { "test" },
-					"testResults/html/localization/INPUT",
-					"src/test/resources/reference/html/localization");
-
-			/*
-			 * A simple model to test the creation of a docx feature catalogue
-			 */
-			docxTest("src/test/resources/config/testEA_Docx.xml",
-					new String[] { "test" }, "testResults/docx/myInputId",
-					"src/test/resources/reference/docx");
-
-			/*
-			 * A simple model to test the creation of a docx feature catalogue
-			 * that includes UML diagrams
-			 */
-			// TODO image file names and sizes not stable
-			// docxTest("src/test/resources/config/testEA_Docx_FC_with_images.xml",
-			// new String[]{"test_featurecatalog_with_images"},
-			// "testResults/docx_with_images/myInputId",
-			// "src/test/resources/reference/docx");
-
-			/*
-			 * A test model where documentation is retrieved from classifiers
-			 * that are suppliers of a dependency (feature, attribute and value
-			 * concepts)
-			 */
-			xsdTest("src/test/resources/config/testEA_dep.xml", xsdTest, null,
-					"testResults/ea/INPUT", "src/test/resources/reference/xsd");
-
-			/*
-			 * A simple CityGML Application Domain Extension (ADE)
-			 */
-			String[] xsdADE = { "ade" };
-			xsdTest("src/test/resources/config/testEA_ADE.xml", xsdADE, null,
-					"testResults/ea/INPUT", "src/test/resources/reference/xsd");
-
-			/*
-			 * Qualified associations as well as array and list properties. Note
-			 * that there are errors reported during the conversion (on purpose)
-			 * unlike in most other tests.
-			 */
-			String[] xsdaaask = { "testaaask" };
-			xsdTest("src/test/resources/config/testEA_aaa-sk.xml", xsdaaask,
-					null, "testResults/ea/INPUT",
-					"src/test/resources/reference/xsd", false);
-
-			/*
-			 * An association class and the GML 3.3 code list values
-			 */
-			String[] xsdgml33 = { "testgml33" };
-			xsdTest("src/test/resources/config/testEA_gml33.xml", xsdgml33,
-					xsdgml33, "testResults/ea/INPUT",
-					"src/test/resources/reference/xsd");
-
-			/*
-			 * Test the mixin options
-			 */
-			String[] xsdmixin = { "testgroupmixin" };
-			xsdTest("src/test/resources/config/testEA_groupmixin.xml", xsdmixin,
-					null, "testResults/ea/INPUT",
-					"src/test/resources/reference/xsd");
-
-			/*
-			 * A simple 19115 metadata profile and Schematron tests
-			 */
-			String[] xsdmd = { "testbasetypes", "testprofile", "testlet" };
-			String[] schmd = { "testprofile", "testlet" };
-			xsdTest("src/test/resources/config/testEA_md.xml", xsdmd, schmd,
-					"testResults/ea/md/INPUT",
-					"src/test/resources/reference/xsd");
-
-			/*
-			 * The SWE Common 2.0 encoding
-			 */
-			String[] xsdswe = { "advanced_encodings", "basic_types",
-					"block_components", "choice_components",
-					"record_components", "simple_components",
-					"simple_encodings", "swe" };
-			xsdTest("src/test/resources/config/testEA_swe.xml", xsdswe, null,
-					"testResults/ea/swe/INPUT",
-					"src/test/resources/reference/xsd/swe");
-
-			// TODO add INSPIRE, OKSTRA, no GML, more Schematron tests
-
-			/*
-			 * JSON encoding with geoservices encoding rule
-			 */
-			String[] typenamesGsr = { "FeatureType1", "FeatureType2" };
-			jsonTest("src/test/resources/config/testEA_JsonGsr.xml",
-					typenamesGsr, "testResults/ea/json/geoservices/INPUT",
-					"src/test/resources/reference/json/geoservices");
-
-			/*
-			 * JSON encoding with extended geoservices encoding rule
-			 */
-			String[] typenamesGsrExtended = { "DataType", "DataType2",
-					"FeatureType1", "FeatureType2", "NilUnion", "Union" };
-			jsonTest("src/test/resources/config/testEA_JsonGsrExtended.xml",
-					typenamesGsrExtended,
-					"testResults/ea/json/geoservices_extended/INPUT",
-					"src/test/resources/reference/json/geoservices_extended");
-
-			/*
-			 * SKOS codelists
-			 */
-			String[] rdfskos = { "Codelists" };
-			rdfTest("src/test/resources/config/testEA_skos.xml", rdfskos,
-					"testResults/ea/skos/INPUT",
-					"src/test/resources/reference/rdf/skos");
-
-			/*
-			 * Ontology (based on ISO 19150-2) - single ontology per schema 
-			 */
-			multiTest(
-					"src/test/resources/config/testEA_owliso_singleOntologyPerSchema.xml",
-					new String[] { "ttl" },
-					"testResults/owl/singleOntologyPerSchema/owl",
-					"src/test/resources/reference/owl/singleOntologyPerSchema/owl");
-			
-			/*
-			 * Ontology (based on ISO 19150-2) - multiple ontologies - one per package 
-			 */
-			multiTest(
-					"src/test/resources/config/testEA_owliso_multipleOntologiesPerSchema.xml",
-					new String[] { "ttl" },
-					"testResults/owl/multipleOntologiesPerSchema/owl",
-					"src/test/resources/reference/owl/multipleOntologiesPerSchema/owl");
-			
-			/*
-			 * Flattening transformation
-			 */
-			multiTest("src/test/resources/config/testEA_Flattening.xml",
-					new String[] { "xsd" }, "testResults/flattening/xsd",
-					"src/test/resources/reference/flattening/xsd");
-
-			/*
-			 * Flattening transformation - only homogeneous geometries
-			 */
-			multiTest(
-					"src/test/resources/config/testEA_Flattening_homogeneousGeometries.xml",
-					new String[] { "xsd" },
-					"testResults/flattening/homogeneousGeometry_core/",
-					"src/test/resources/reference/flattening/homogeneousGeometry");
-
-			/*
-			 * Flattening transformation - only homogeneous geometries - Test1
-			 * (handling of associations)
-			 */
-			multiTest(
-					"src/test/resources/config/testEA_Flattening_homogeneousGeometries_test1.xml",
-					new String[] { "xsd" },
-					"testResults/flattening/homogeneousGeometry_test1/",
-					"src/test/resources/reference/flattening/homogeneousGeometry_test1");
-
-			/*
-			 * Flattening transformation - only inheritance
-			 */
-			multiTest(
-					"src/test/resources/config/testEA_Flattening_inheritance.xml",
-					new String[] { "xsd" },
-					"testResults/flattening/inheritance/",
-					"src/test/resources/reference/flattening/inheritance");
-
-			/*
-			 * Flattening transformation - removing inheritance
-			 */
-			multiTest("src/test/resources/config/testEA_Flattening_removeInheritance.xml",
-					new String[] { "xsd" }, "testResults/flattening/removeInheritance/xsd",
-					"src/test/resources/reference/flattening/removeInheritance/xsd");
-			
-			/*
-			 * Flattening transformation - cycles (and isFlatTarget setting)
-			 */
-			multiTest("src/test/resources/config/testEA_Flattening_cycles.xml",
-					new String[] { "xsd" },
-					"testResults/flattening/xsd/cycles_step1",
-					"src/test/resources/reference/flattening/xsd/cycles_step1");
-
-			/*
-			 * Flattening transformation - remove feature-2-feature
-			 * relationships
-			 */
-			multiTest(
-					"src/test/resources/config/testEA_Flattening_removeFeatureTypeRelationships.xml",
-					new String[] { "xsd" },
-					"testResults/flattening/removeFeatureTypeRelationships",
-					"src/test/resources/reference/flattening/removeFeatureTypeRelationships");
-
-			/*
-			 * Flattening transformation - remove object-2-feature relationships
-			 * for specific object types
-			 */
-			multiTest(
-					"src/test/resources/config/testEA_Flattening_removeObjectToFeatureTypeNavigability.xml",
-					new String[] { "xsd" },
-					"testResults/flattening/removeObjectToFeatureTypeNavigability",
-					"src/test/resources/reference/flattening/removeObjectToFeatureTypeNavigability");
-
-			/*
-			 * Replication schema target
-			 */
-			multiTest("src/test/resources/config/testEA_repSchema.xml",
-					new String[] { "xsd" }, "testResults/repSchema/repXsd",
-					"src/test/resources/reference/xsd/replicationSchema");
-
-			/*
-			 * Attribute creation transformer
-			 */
-			multiTest("src/test/resources/config/testEA_attributeCreation.xml",
-					new String[] { "xsd" },
-					"testResults/attribute_creation/xsd",
-					"src/test/resources/reference/xsd/attributeCreation");
-
-			/*
-			 * Test the profiling functionality
-			 */
-			multiTest("src/test/resources/config/testEA_Profiling.xml",
-					new String[] { "xsd", "xml" }, "testResults/profiling/xsd",
-					"src/test/resources/reference/profiling/xsd");
-
-			/*
-			 * Test the constraint validation functionality
-			 */
-			multiTest(
-					"src/test/resources/config/testEA_Profiling_withConstraintValidation.xml",
-					new String[] { "xml" },
-					"testResults/profiling/constraintValidation/results",
-					"src/test/resources/reference/profiling/constraintValidation/results");
-
-			/*
-			 * Test the profiling functionality - with explicit profile settings
-			 * behavior
-			 */
-			multiTest(
-					"src/test/resources/config/testEA_Profiling_explicitProfileSettings.xml",
-					new String[] { "xsd", "xml" },
-					"testResults/profiling_explicitProfileSettings/xsd",
-					"src/test/resources/reference/profiling_explicitProfileSettings/xsd");
-
-			// /*
-			// * Test the creation of a frame-based html feature catalogue
-			// */
-			// multiTest("src/test/resources/config/testEA_HtmlFrame.xml",
-			// new String[] { "html" }, "testResults/html/frame/INPUT",
-			// "src/test/resources/reference/html/frame/INPUT");
-
-			/*
-			 * Schematron derived from SBVR (with intermediate translation to
-			 * FOL)
-			 */
-			multiTest("src/test/resources/config/testEA_Sbvr.xml",
-					new String[] { "xml" },
-					"testResults/fol/fromSbvr/sch/step3",
-					"src/test/resources/reference/sch/fromSbvr");
-
-			/*
-			 * Test the GML 3.3 based transformation of association classes.
-			 */
-			multiTest(
-					"src/test/resources/config/testEA_associationClassMapper.xml",
-					new String[] { "xsd" },
-					"testResults/associationClassTransform/associationClassMapper",
-					"src/test/resources/reference/associationClassTransform/associationClassMapper");
-		}
-	}
-
-	private void multiTest(String config, String[] fileFormatsToCheck,
+	// /*
+	// * Test the creation of a frame-based html feature catalogue
+	// */
+	// multiTest("src/test/resources/config/testEA_HtmlFrame.xml",
+	// new String[] { "html" }, "testResults/html/frame/INPUT",
+	// "src/test/resources/reference/html/frame/INPUT");
+	
+	protected void multiTest(String config, String[] fileFormatsToCheck,
 			String basedirResults, String basedirReference) {
 
 		Set<String> fileFormatsToCheckLC = null;
@@ -810,26 +365,26 @@ public class BasicTest {
 		}
 	}
 
-	private void xsdTest(String config, String[] xsds, String[] schs,
+	protected void xsdTest(String config, String[] xsds, String[] schs,
 			String basedirResults, String basedirReference) {
 		xsdTest(config, xsds, schs, null, basedirResults, basedirReference,
 				true);
 	}
 
-	private void xsdTest(String config, String[] xsds, String[] schs,
+	protected void xsdTest(String config, String[] xsds, String[] schs,
 			HashMap<String, String> replacevalues, String basedirResults,
 			String basedirReference) {
 		xsdTest(config, xsds, schs, replacevalues, basedirResults,
 				basedirReference, true);
 	}
 
-	private void xsdTest(String config, String[] xsds, String[] schs,
+	protected void xsdTest(String config, String[] xsds, String[] schs,
 			String basedirResults, String basedirReference, boolean noErrors) {
 		xsdTest(config, xsds, schs, null, basedirResults, basedirReference,
 				noErrors);
 	}
 
-	private void xsdTest(String config, String[] xsds, String[] schs,
+	protected void xsdTest(String config, String[] xsds, String[] schs,
 			HashMap<String, String> replacevalues, String basedirResults,
 			String basedirReference, boolean noErrors) {
 		long start = (new Date()).getTime();
@@ -872,7 +427,7 @@ public class BasicTest {
 		sqlTest(config, sqls, null, basedirResults, basedirReference, noErrors);
 	}
 
-	private void sqlTest(String config, String[] sqls,
+	protected void sqlTest(String config, String[] sqls,
 			HashMap<String, String> replacevalues, String basedirResults,
 			String basedirReference, boolean noErrors) {
 
@@ -897,7 +452,7 @@ public class BasicTest {
 		}
 	}
 
-	private void jsonTest(String config, String[] typenames,
+	protected void jsonTest(String config, String[] typenames,
 			String basedirResults, String basedirReference) {
 		long start = (new Date()).getTime();
 		TestInstance test = new TestInstance(config);
@@ -931,7 +486,7 @@ public class BasicTest {
 		}
 	}
 
-	private void rdfTest(String config, String[] rdfs, String basedirResults,
+	protected void rdfTest(String config, String[] rdfs, String basedirResults,
 			String basedirReference) {
 		long start = (new Date()).getTime();
 		TestInstance test = new TestInstance(config);
@@ -996,7 +551,7 @@ public class BasicTest {
 		}
 	}
 
-	private void htmlTest(String config, String[] htmls, String basedirResults,
+	protected void htmlTest(String config, String[] htmls, String basedirResults,
 			String basedirReference) {
 		long start = (new Date()).getTime();
 		TestInstance test = new TestInstance(config);
@@ -1062,7 +617,7 @@ public class BasicTest {
 	}
 
 
-	private void docxTest(String config, String[] docxs, String basedirResults,
+	protected void docxTest(String config, String[] docxs, String basedirResults,
 			String basedirReference) {
 		long start = (new Date()).getTime();
 		TestInstance test = new TestInstance(config);
@@ -1217,7 +772,8 @@ public class BasicTest {
 		}
 	}
 
-	private void initialise() {
+	@Before
+	public void initialise() {
 		System.setProperty("javax.xml.parsers.DocumentBuilderFactory",
 				"org.apache.xerces.jaxp.DocumentBuilderFactoryImpl");
 		System.setProperty("javax.xml.parsers.SAXParserFactory",

--- a/src/test/java/de/interactive_instruments/ShapeChange/FOL2SchematronTest.java
+++ b/src/test/java/de/interactive_instruments/ShapeChange/FOL2SchematronTest.java
@@ -1,0 +1,19 @@
+package de.interactive_instruments.ShapeChange;
+
+import org.junit.Test;
+
+public class FOL2SchematronTest extends WindowsBasicTest {
+	
+	@Test
+	public void testFOL2Schematron() {
+		/*
+		 * Schematron derived from SBVR (with intermediate translation to
+		 * FOL)
+		 */
+		multiTest("src/test/resources/config/testEA_Sbvr.xml",
+				new String[] { "xml" },
+				"testResults/fol/fromSbvr/sch/step3",
+				"src/test/resources/reference/sch/fromSbvr");
+	}
+
+}

--- a/src/test/java/de/interactive_instruments/ShapeChange/FeatureCatalogueTest.java
+++ b/src/test/java/de/interactive_instruments/ShapeChange/FeatureCatalogueTest.java
@@ -1,0 +1,66 @@
+package de.interactive_instruments.ShapeChange;
+
+import org.junit.Test;
+
+public class FeatureCatalogueTest extends WindowsBasicTest {
+	
+	@Test
+	public void testSingleFileHtmlFeatureCatalogue() {
+		/*
+		 * A simple model to test the creation of a single-file html feature
+		 * catalogue
+		 */
+		htmlTest("src/test/resources/config/testEA_Html.xml",
+				new String[] { "test" }, "testResults/html/INPUT",
+				"src/test/resources/reference/html");
+	}
+
+	@Test
+	public void testLocalizationFunctionality() {
+		/*
+		 * A simple model to test the localization functionality
+		 */
+		htmlTest("src/test/resources/config/testEA_HtmlLocalization.xml",
+				new String[] { "test" },
+				"testResults/html/localization/INPUT",
+				"src/test/resources/reference/html/localization");
+	}
+
+	@Test
+	public void testDocxFeatureCatalogue() {
+		/*
+		 * A simple model to test the creation of a docx feature catalogue
+		 */
+		docxTest("src/test/resources/config/testEA_Docx.xml",
+				new String[] { "test" }, "testResults/docx/myInputId",
+				"src/test/resources/reference/docx");
+	}
+	
+	@Test
+	public void testInheritedPropertiesAndNoAlphabeticSortingForProperties() {
+		/*
+		 * Test creation of an HTML feature catalogue with
+		 * inheritedProperties=true and noAlphabeticSortingForProperties =
+		 * true
+		 */
+		multiTest(
+				"src/test/resources/config/testEA_fc_inheritedProperties.xml",
+				new String[] { "xml", "html" },
+				"testResults/html/inheritedProperties/INPUT",
+				"src/test/resources/reference/html/inheritedProperties/INPUT");
+	}
+	
+	@Test
+	public void testDerivationOfApplicationSchemaDifferences() {
+		/*
+		 * Test derivation of application schema differences (output as
+		 * single page HTML feature catalogue).
+		 */
+		multiTest("src/test/resources/config/testEA_model_diff.xml",
+				new String[] { "xml", "html" },
+				"testResults/html/diff/INPUT",
+				"src/test/resources/reference/html/diff/INPUT");
+	}
+
+
+}

--- a/src/test/java/de/interactive_instruments/ShapeChange/FlattenerTest.java
+++ b/src/test/java/de/interactive_instruments/ShapeChange/FlattenerTest.java
@@ -1,0 +1,86 @@
+package de.interactive_instruments.ShapeChange;
+
+import org.junit.Test;
+
+public class FlattenerTest extends WindowsBasicTest {
+
+	@Test
+	public void testFlattening1() {
+		/*
+		 * Flattening transformation
+		 */
+		multiTest("src/test/resources/config/testEA_Flattening.xml", new String[] { "xsd" },
+				"testResults/flattening/xsd", "src/test/resources/reference/flattening/xsd");
+	}
+
+	@Test
+	public void testFlattening2() {
+		/*
+		 * Flattening transformation - only homogeneous geometries
+		 */
+		multiTest("src/test/resources/config/testEA_Flattening_homogeneousGeometries.xml", new String[] { "xsd" },
+				"testResults/flattening/homogeneousGeometry_core/",
+				"src/test/resources/reference/flattening/homogeneousGeometry");
+	}
+
+	@Test
+	public void testFlattening3() {
+		/*
+		 * Flattening transformation - only homogeneous geometries - Test1
+		 * (handling of associations)
+		 */
+		multiTest("src/test/resources/config/testEA_Flattening_homogeneousGeometries_test1.xml", new String[] { "xsd" },
+				"testResults/flattening/homogeneousGeometry_test1/",
+				"src/test/resources/reference/flattening/homogeneousGeometry_test1");
+	}
+
+	@Test
+	public void testFlattening4() {
+		/*
+		 * Flattening transformation - only inheritance
+		 */
+		multiTest("src/test/resources/config/testEA_Flattening_inheritance.xml", new String[] { "xsd" },
+				"testResults/flattening/inheritance/", "src/test/resources/reference/flattening/inheritance");
+	}
+
+	@Test
+	public void testFlattening5() {
+		/*
+		 * Flattening transformation - removing inheritance
+		 */
+		multiTest("src/test/resources/config/testEA_Flattening_removeInheritance.xml", new String[] { "xsd" },
+				"testResults/flattening/removeInheritance/xsd",
+				"src/test/resources/reference/flattening/removeInheritance/xsd");
+	}
+
+	@Test
+	public void testFlattening6() {
+		/*
+		 * Flattening transformation - cycles (and isFlatTarget setting)
+		 */
+		multiTest("src/test/resources/config/testEA_Flattening_cycles.xml", new String[] { "xsd" },
+				"testResults/flattening/xsd/cycles_step1", "src/test/resources/reference/flattening/xsd/cycles_step1");
+	}
+
+	@Test
+	public void testFlattening7() {
+		/*
+		 * Flattening transformation - remove feature-2-feature relationships
+		 */
+		multiTest("src/test/resources/config/testEA_Flattening_removeFeatureTypeRelationships.xml",
+				new String[] { "xsd" }, "testResults/flattening/removeFeatureTypeRelationships",
+				"src/test/resources/reference/flattening/removeFeatureTypeRelationships");
+	}
+
+	@Test
+	public void testFlattening8() {
+		/*
+		 * Flattening transformation - remove object-2-feature relationships for
+		 * specific object types
+		 */
+		multiTest("src/test/resources/config/testEA_Flattening_removeObjectToFeatureTypeNavigability.xml",
+				new String[] { "xsd" }, "testResults/flattening/removeObjectToFeatureTypeNavigability",
+				"src/test/resources/reference/flattening/removeObjectToFeatureTypeNavigability");
+	}
+
+}

--- a/src/test/java/de/interactive_instruments/ShapeChange/JSONTest.java
+++ b/src/test/java/de/interactive_instruments/ShapeChange/JSONTest.java
@@ -1,0 +1,31 @@
+package de.interactive_instruments.ShapeChange;
+
+import org.junit.Test;
+
+public class JSONTest extends WindowsBasicTest {
+	
+	@Test
+	public void testJsonWithGeoservicesEncodingRule() {
+		/*
+		 * JSON encoding with geoservices encoding rule
+		 */
+		String[] typenamesGsr = { "FeatureType1", "FeatureType2" };
+		jsonTest("src/test/resources/config/testEA_JsonGsr.xml",
+				typenamesGsr, "testResults/ea/json/geoservices/INPUT",
+				"src/test/resources/reference/json/geoservices");
+	}
+
+	@Test
+	public void testJsonWithExtendedGeoservicesEncodingRule() {
+		/*
+		 * JSON encoding with extended geoservices encoding rule
+		 */
+		String[] typenamesGsrExtended = { "DataType", "DataType2",
+				"FeatureType1", "FeatureType2", "NilUnion", "Union" };
+		jsonTest("src/test/resources/config/testEA_JsonGsrExtended.xml",
+				typenamesGsrExtended,
+				"testResults/ea/json/geoservices_extended/INPUT",
+				"src/test/resources/reference/json/geoservices_extended");
+	}
+
+}

--- a/src/test/java/de/interactive_instruments/ShapeChange/MinimalAndTesttXmiModelTest.java
+++ b/src/test/java/de/interactive_instruments/ShapeChange/MinimalAndTesttXmiModelTest.java
@@ -1,0 +1,33 @@
+package de.interactive_instruments.ShapeChange;
+
+import java.io.InputStream;
+import java.net.URL;
+
+import org.junit.Test;
+
+public class MinimalAndTesttXmiModelTest extends BasicTest {
+
+	@Test
+	public void testMinimalAndTestXmiModels() {
+		/*
+		 * Invoke without parameters, if we are connected
+		 */
+		try {
+			URL url = new URL(
+					"http://shapechange.net/resources/config/minimal.xml");
+			InputStream configStream = url.openStream();
+			if (configStream != null) {
+				xsdTest(null, new String[] { "test" }, null, ".",
+						"src/test/resources/reference/xsd");
+			}
+		} catch (Exception e) {
+		}
+	
+		/*
+		 * Process the XMI 1.0 test model
+		 */
+		xsdTest("src/test/resources/config/testXMI.xml", new String[] { "test" }, null,
+				"testResults/xmi/INPUT", "src/test/resources/reference/xsd");
+	}
+
+}

--- a/src/test/java/de/interactive_instruments/ShapeChange/OntologyTest.java
+++ b/src/test/java/de/interactive_instruments/ShapeChange/OntologyTest.java
@@ -1,0 +1,38 @@
+package de.interactive_instruments.ShapeChange;
+
+import org.junit.Test;
+
+public class OntologyTest extends WindowsBasicTest {
+
+	@Test
+	public void testSkosCodelists() {
+		/*
+		 * SKOS codelists
+		 */
+		String[] rdfskos = { "Codelists" };
+		rdfTest("src/test/resources/config/testEA_skos.xml", rdfskos, "testResults/ea/skos/INPUT",
+				"src/test/resources/reference/rdf/skos");
+	}
+
+	@Test
+	public void testSingleOntologyPerSchema() {
+		/*
+		 * Ontology (based on ISO 19150-2) - single ontology per schema
+		 */
+		multiTest("src/test/resources/config/testEA_owliso_singleOntologyPerSchema.xml", new String[] { "ttl" },
+				"testResults/owl/singleOntologyPerSchema/owl",
+				"src/test/resources/reference/owl/singleOntologyPerSchema/owl");
+	}
+
+	@Test
+	public void testMultipleOntologiesOnePerPackage() {
+		/*
+		 * Ontology (based on ISO 19150-2) - multiple ontologies - one per
+		 * package
+		 */
+		multiTest("src/test/resources/config/testEA_owliso_multipleOntologiesPerSchema.xml", new String[] { "ttl" },
+				"testResults/owl/multipleOntologiesPerSchema/owl",
+				"src/test/resources/reference/owl/multipleOntologiesPerSchema/owl");
+	}
+
+}

--- a/src/test/java/de/interactive_instruments/ShapeChange/ProfilerTest.java
+++ b/src/test/java/de/interactive_instruments/ShapeChange/ProfilerTest.java
@@ -1,0 +1,42 @@
+package de.interactive_instruments.ShapeChange;
+
+import org.junit.Test;
+
+public class ProfilerTest extends WindowsBasicTest {
+	
+	@Test
+	public void testProfilingFunctionality() {
+		/*
+		 * Test the profiling functionality
+		 */
+		multiTest("src/test/resources/config/testEA_Profiling.xml",
+				new String[] { "xsd", "xml" }, "testResults/profiling/xsd",
+				"src/test/resources/reference/profiling/xsd");
+	}
+	
+	@Test
+	public void testProfilingWithConstraintValidation() {
+		/*
+		 * Test the constraint validation functionality
+		 */
+		multiTest(
+				"src/test/resources/config/testEA_Profiling_withConstraintValidation.xml",
+				new String[] { "xml" },
+				"testResults/profiling/constraintValidation/results",
+				"src/test/resources/reference/profiling/constraintValidation/results");
+	}
+
+	@Test
+	public void testProfilingWithExplicitProfileSettingsBehavior() {
+		/*
+		 * Test the profiling functionality - with explicit profile settings
+		 * behavior
+		 */
+		multiTest(
+				"src/test/resources/config/testEA_Profiling_explicitProfileSettings.xml",
+				new String[] { "xsd", "xml" },
+				"testResults/profiling_explicitProfileSettings/xsd",
+				"src/test/resources/reference/profiling_explicitProfileSettings/xsd");
+	}
+
+}

--- a/src/test/java/de/interactive_instruments/ShapeChange/ReplicationXMLSchemaTest.java
+++ b/src/test/java/de/interactive_instruments/ShapeChange/ReplicationXMLSchemaTest.java
@@ -1,0 +1,17 @@
+package de.interactive_instruments.ShapeChange;
+
+import org.junit.Test;
+
+public class ReplicationXMLSchemaTest extends WindowsBasicTest {
+	
+	@Test
+	public void testReplicationSchema() {
+		/*
+		 * Replication schema target
+		 */
+		multiTest("src/test/resources/config/testEA_repSchema.xml",
+				new String[] { "xsd" }, "testResults/repSchema/repXsd",
+				"src/test/resources/reference/xsd/replicationSchema");
+	}
+
+}

--- a/src/test/java/de/interactive_instruments/ShapeChange/SQLTest.java
+++ b/src/test/java/de/interactive_instruments/ShapeChange/SQLTest.java
@@ -1,0 +1,40 @@
+package de.interactive_instruments.ShapeChange;
+
+import org.junit.Test;
+
+public class SQLTest extends WindowsBasicTest {
+	
+	@Test
+	public void testBasicSQL() {
+		/*
+		 * SQL - basic text
+		 */
+		multiTest("src/test/resources/config/testEA_sql.xml",
+				new String[] { "sql" }, "testResults/sql/basic",
+				"src/test/resources/reference/sql/basic");
+	}
+
+	@Test
+	public void testGeometryParameters() {
+		/*
+		 * SQL - geometry parameters test
+		 */
+		multiTest(
+				"src/test/resources/config/testEA_sqlGeometryParameters.xml",
+				new String[] { "sql" },
+				"testResults/sql/geometryParameters",
+				"src/test/resources/reference/sql/geometryParameters");
+	}
+
+	@Test
+	public void testAssociativeTables() {
+		/*
+		 * SQL - associative tables tests
+		 */
+		multiTest(
+				"src/test/resources/config/testEA_sqlAssociativeTables.xml",
+				new String[] { "sql" }, "testResults/sql/associativeTables",
+				"src/test/resources/reference/sql/associativeTables");
+	}
+
+}

--- a/src/test/java/de/interactive_instruments/ShapeChange/VariousFunctionalityTest.java
+++ b/src/test/java/de/interactive_instruments/ShapeChange/VariousFunctionalityTest.java
@@ -1,0 +1,39 @@
+package de.interactive_instruments.ShapeChange;
+
+import org.junit.Test;
+
+public class VariousFunctionalityTest extends WindowsBasicTest {
+	
+	@Test
+	public void testDescriptorFunctionality() {
+		/*
+		 * Test the descriptor functionality
+		 */
+		multiTest("src/test/resources/config/testEA_descriptors_fc_en.xml",
+				new String[] { "xml", "html" },
+				"testResults/html/descriptors/INPUT",
+				"src/test/resources/reference/html/descriptors");
+		
+		multiTest("src/test/resources/config/testEA_descriptors_fc_de.xml",
+				new String[] { "xml", "html" },
+				"testResults/html/descriptors/INPUT",
+				"src/test/resources/reference/html/descriptors");
+		
+		multiTest(
+				"src/test/resources/config/testEA_descriptors_inspire.xml",
+				new String[] { "xml", "html" },
+				"testResults/html/descriptors/INPUT",
+				"src/test/resources/reference/html/descriptors");
+		
+		multiTest("src/test/resources/config/testEA_descriptors_aaa.xml",
+				new String[] { "xml", "html" },
+				"testResults/html/descriptors/INPUT",
+				"src/test/resources/reference/html/descriptors");
+		
+		multiTest("src/test/resources/config/testEA_descriptors_bbr.xml",
+				new String[] { "xml", "html" },
+				"testResults/html/descriptors/INPUT",
+				"src/test/resources/reference/html/descriptors");
+	}
+
+}

--- a/src/test/java/de/interactive_instruments/ShapeChange/WindowsBasicTest.java
+++ b/src/test/java/de/interactive_instruments/ShapeChange/WindowsBasicTest.java
@@ -1,0 +1,15 @@
+package de.interactive_instruments.ShapeChange;
+
+import static org.junit.Assume.assumeTrue;
+
+import org.apache.commons.lang.SystemUtils;
+import org.junit.Before;
+
+public class WindowsBasicTest extends BasicTest {
+	
+	@Before
+	public void assumeWindows() {
+		assumeTrue(SystemUtils.IS_OS_WINDOWS);
+	}
+
+}

--- a/src/test/java/de/interactive_instruments/ShapeChange/XMLSchemaTest.java
+++ b/src/test/java/de/interactive_instruments/ShapeChange/XMLSchemaTest.java
@@ -1,0 +1,194 @@
+package de.interactive_instruments.ShapeChange;
+
+import java.util.HashMap;
+
+import org.junit.Test;
+
+public class XMLSchemaTest extends WindowsBasicTest {
+	
+	@Test
+	public void xmlSchemaTest1() {
+		/*
+		 * First the same test model as the XMI 1.0 test model
+		 */
+		xsdTest("src/test/resources/config/testEA.xml", new String[] { "test" }, null,
+				"testResults/ea/INPUT", "src/test/resources/reference/xsd");
+	}
+
+	@Test
+	public void xmlSchemaTest2() {
+		/*
+		 * Now with some replacement values
+		 */
+		HashMap<String, String> replace = new HashMap<String, String>();
+		replace.put("$eap$", "src/test/resources/test.eap");
+		replace.put("$log$", "testResults/ea/log.xml");
+		replace.put("$out$", "testResults/ea");
+		xsdTest("src/test/resources/config/testEA_x.xml", new String[] { "test" }, null,
+				replace, "testResults/ea/INPUT",
+				"src/test/resources/reference/xsd");
+	}
+
+	@Test
+	public void xmlSchemaTest3() {
+		/*
+		 * Test property options: ordered, uniqueness and inline/byReference
+		 */
+		multiTest("src/test/resources/config/testEA_prop.xml",
+				new String[] { "xsd", "xml", "html" },
+				"testResults/ea/prop/INPUT",
+				"src/test/resources/reference/prop");
+	}
+
+	@Test
+	public void xmlSchemaTest4() {
+		/*
+		 * Test multiple tagged values and stereotypes
+		 */
+		HashMap<String, String> replace2 = new HashMap<String, String>();
+		replace2.put("$tvimpl$", "");
+		replace2.put("$logout$",
+				"testResults/multipleTaggedValuesAndStereotypes/tv_map_impl/log.xml");
+		replace2.put("$xsdout$",
+				"testResults/multipleTaggedValuesAndStereotypes/tv_map_impl");
+		xsdTest("src/test/resources/config/testEA_multipleTaggedValuesAndStereotypes.xml",
+				new String[] { "multTvAndSt" }, null, replace2,
+				"testResults/multipleTaggedValuesAndStereotypes/tv_map_impl/INPUT",
+				"src/test/resources/reference/xsd/multipleTaggedValuesAndStereotypes/INPUT");
+	}
+
+	@Test
+	public void xmlSchemaTest5() {
+		HashMap<String, String> replace21;
+		/*
+		 * Test multiple tagged values and stereotypes - with array
+		 * implementation for tagged values.
+		 */
+		replace21 = new HashMap<String, String>();
+		replace21.put("$tvimpl$", "array");
+		replace21.put("$logout$",
+				"testResults/multipleTaggedValuesAndStereotypes/tv_array_impl/log.xml");
+		replace21.put("$xsdout$",
+				"testResults/multipleTaggedValuesAndStereotypes/tv_array_impl");
+		xsdTest("src/test/resources/config/testEA_multipleTaggedValuesAndStereotypes.xml",
+				new String[] { "multTvAndSt" }, null, replace21,
+				"testResults/multipleTaggedValuesAndStereotypes/tv_array_impl/INPUT",
+				"src/test/resources/reference/xsd/multipleTaggedValuesAndStereotypes/INPUT");
+	}
+
+	@Test
+	public void xmlSchemaTest6() {
+		/*
+		 * Test rule-xsd-cls-codelist-constraints-codeAbsenceInModelAllowed.
+		 */
+		multiTest("src/test/resources/config/testEA_codeAbsenceInModel.xml",
+				new String[] { "xml" },
+				"testResults/codeAbsenceInModel/input",
+				"src/test/resources/reference/xsd/codeAbsenceInModel/input");
+	}
+
+	@Test
+	public void xmlSchemaTest7() {
+		/*
+		 * Test XML Schema creation for Application Schema with multiple
+		 * packages that shall be output as individual xsd files.
+		 */
+		multiTest("src/test/resources/config/testEA_packageIncludes.xml",
+				new String[] { "xsd" }, "testResults/xsd/packageIncludes",
+				"src/test/resources/reference/xsd/packageIncludes");
+	}
+
+	@Test
+	public void xmlSchemaTest8() {
+		/*
+		 * Test XML Schema creation for two Application Schema, with
+		 * identity transformation.
+		 */
+		multiTest("src/test/resources/config/testEA_MultipleAppSchema.xml",
+				new String[] { "xsd" }, "testResults/xsd/multiAppSchema",
+				"src/test/resources/reference/xsd/multiAppSchema");
+	}
+
+	@Test
+	public void xmlSchemaTest9() {
+		/*
+		 * A test model where documentation is retrieved from classifiers
+		 * that are suppliers of a dependency (feature, attribute and value
+		 * concepts)
+		 */
+		xsdTest("src/test/resources/config/testEA_dep.xml", new String[] { "test" }, null,
+				"testResults/ea/INPUT", "src/test/resources/reference/xsd");
+	}
+
+	@Test
+	public void xmlSchemaTest10() {
+		/*
+		 * A simple CityGML Application Domain Extension (ADE)
+		 */
+		String[] xsdADE = { "ade" };
+		xsdTest("src/test/resources/config/testEA_ADE.xml", xsdADE, null,
+				"testResults/ea/INPUT", "src/test/resources/reference/xsd");
+	}
+
+	@Test
+	public void xmlSchemaTest11() {
+		/*
+		 * Qualified associations as well as array and list properties. Note
+		 * that there are errors reported during the conversion (on purpose)
+		 * unlike in most other tests.
+		 */
+		String[] xsdaaask = { "testaaask" };
+		xsdTest("src/test/resources/config/testEA_aaa-sk.xml", xsdaaask,
+				null, "testResults/ea/INPUT",
+				"src/test/resources/reference/xsd", false);
+	}
+
+	@Test
+	public void xmlSchemaTest12() {
+		/*
+		 * An association class and the GML 3.3 code list values
+		 */
+		String[] xsdgml33 = { "testgml33" };
+		xsdTest("src/test/resources/config/testEA_gml33.xml", xsdgml33,
+				xsdgml33, "testResults/ea/INPUT",
+				"src/test/resources/reference/xsd");
+	}
+
+	@Test
+	public void xmlSchemaTest13() {
+		/*
+		 * Test the mixin options
+		 */
+		String[] xsdmixin = { "testgroupmixin" };
+		xsdTest("src/test/resources/config/testEA_groupmixin.xml", xsdmixin,
+				null, "testResults/ea/INPUT",
+				"src/test/resources/reference/xsd");
+	}
+
+	@Test
+	public void xmlSchemaTest14() {
+		/*
+		 * A simple 19115 metadata profile and Schematron tests
+		 */
+		String[] xsdmd = { "testbasetypes", "testprofile", "testlet" };
+		String[] schmd = { "testprofile", "testlet" };
+		xsdTest("src/test/resources/config/testEA_md.xml", xsdmd, schmd,
+				"testResults/ea/md/INPUT",
+				"src/test/resources/reference/xsd");
+	}
+
+	@Test
+	public void xmlSchemaTest15() {
+		/*
+		 * The SWE Common 2.0 encoding
+		 */
+		String[] xsdswe = { "advanced_encodings", "basic_types",
+				"block_components", "choice_components",
+				"record_components", "simple_components",
+				"simple_encodings", "swe" };
+		xsdTest("src/test/resources/config/testEA_swe.xml", xsdswe, null,
+				"testResults/ea/swe/INPUT",
+				"src/test/resources/reference/xsd/swe");
+	}
+
+}


### PR DESCRIPTION
Running all the tests takes quite a long time. Often it would be handy to be able to run a handful of tests, e.g. when working on a particular target. Especially if there is an error somewhere, and one would like to focus on fixing it, and rerunning tests on only the affected code.

Therefore, a proposal to split the class BasicTest, which contains one single test with all test logic, into several test classes, each containing one or more test methods.