### PR TITLE
Add xslTransformerFactory in testEA_Docx.xml

### DIFF
--- a/src/test/resources/config/testEA_Docx.xml
+++ b/src/test/resources/config/testEA_Docx.xml
@@ -23,6 +23,8 @@
 			<targetParameter name="sortedOutput" value="true"/>
 			<targetParameter name="inheritedProperties" value="false"/>
 			<targetParameter name="outputFormat" value="DOCX"/>
+            <targetParameter name="xslTransformerFactory"
+              value="net.sf.saxon.TransformerFactoryImpl" />
 			<targetParameter name="name" value="'Test application schema'"/>
 			<targetParameter name="scope" value="This feature catalogue ..."/>
 			<targetParameter name="versionNumber" value="n/a"/>


### PR DESCRIPTION
targetParameter xslTransformerFactory is missing in testEA_Docx.xml. Without this parameter, an error is given by ShapeChange:

> Parameter 'outputFormat' contains 'DOCX' and/or 'FRAMEHTML'. These formats require an XSLT 2.0 processor, which should be set via the configuration parameter 'xslTransformerFactory'. That parameter was not found, and the default TransformerFactory implementation is not 'net.sf.saxon.TransformerFactoryImpl' (which is known to be an XSLT 2.0 processor); ensure that the parameter is configured correctly.

The tests currently don't fail, since the system property `javax.xml.transform.TransformerFactory` is set to `net.sf.saxon.TransformerFactoryImpl` in code run earlier and is not reset.

The error occurs when running ShapeChange directly on testEA_Docx.xml, or when executing the rearranged tests (#48).