### PR TITLE
Add logging to Flattener when using regexes

### DIFF
--- a/src/main/java/de/interactive_instruments/ShapeChange/ShapeChangeResult.java
+++ b/src/main/java/de/interactive_instruments/ShapeChange/ShapeChangeResult.java
@@ -1076,6 +1076,10 @@ public class ShapeChangeResult {
 			return "(Flattener.java) Multiplicity flattening would usually dissolve the bi-directional association between class '$1$' (property '$2$') and class '$3$' (property '$4$'). Because the rule is to keep all bi-directional associations, the association will not be dissolved and multiplicity flattening won't be applied to it.";
 		case 20343:
 			return "(Flattener.java) Parameter '$1$' is required for the execution of '$2$' but has not been provided. The rule will not be applied.";
+		case 20344:
+			return "(Flattener.java) '$1$' matches regex '$2$', provided in parameter '$3$'";
+		case 20345:
+			return "(Flattener.java) '$1$' does not match regex '$2$', provided in parameter '$3$'";
 
 			/* Generic Model related messages */
 			// (30000-30099) Messages used in multiple generic model classes

--- a/src/main/java/de/interactive_instruments/ShapeChange/Transformation/Flattening/Flattener.java
+++ b/src/main/java/de/interactive_instruments/ShapeChange/Transformation/Flattening/Flattener.java
@@ -3560,10 +3560,10 @@ public class Flattener implements Transformer {
 
 								if (m.matches()) {
 									processType = true;
-									result.addInfo(null, 20344, typeCi.name(), includeObjectTypeRegex, PARAM_FLATTEN_OBJECT_TYPES_INCLUDE_REGEX);
+									result.addDebug(null, 20344, typeCi.name(), includeObjectTypeRegex, PARAM_FLATTEN_OBJECT_TYPES_INCLUDE_REGEX);
 								} else {
 									processType = false;
-									result.addInfo(null, 20345, typeCi.name(), includeObjectTypeRegex, PARAM_FLATTEN_OBJECT_TYPES_INCLUDE_REGEX);
+									result.addDebug(null, 20345, typeCi.name(), includeObjectTypeRegex, PARAM_FLATTEN_OBJECT_TYPES_INCLUDE_REGEX);
 								}
 
 							} else {

--- a/src/main/java/de/interactive_instruments/ShapeChange/Transformation/Flattening/Flattener.java
+++ b/src/main/java/de/interactive_instruments/ShapeChange/Transformation/Flattening/Flattener.java
@@ -832,6 +832,10 @@ public class Flattener implements Transformer {
 				idsOfRelevantSupertypes.add(genCi.id());
 
 				genCi.setSubtypes(null);
+				
+				result.addDebug(null, 20344, genCi.name(), includeRegex, PARAM_REMOVE_INHERITANCE_INCLUDE_REGEX);
+			} else {
+				result.addDebug(null, 20345, genCi.name(), includeRegex, PARAM_REMOVE_INHERITANCE_INCLUDE_REGEX);
 			}
 		}
 
@@ -2548,7 +2552,9 @@ public class Flattener implements Transformer {
 						 * alright, then the type shall be excluded from
 						 * processing
 						 */
+						result.addDebug(null, 20344, genCi.name(), replaceUnionExcludePattern.pattern(), PARAM_REPLACE_UNION_EXCLUDE_REGEX);
 					} else {
+						result.addDebug(null, 20345, genCi.name(), replaceUnionExcludePattern.pattern(), PARAM_REPLACE_UNION_EXCLUDE_REGEX);
 						unionsToProcess.add(genCi);
 					}
 
@@ -3531,8 +3537,10 @@ public class Flattener implements Transformer {
 
 								if (m.matches()) {
 									processType = false;
+									result.addDebug(null, 20344, typeCi.name(), excludeDataTypeRegex, PARAM_FLATTEN_DATATYPES_EXCLUDE_REGEX);
 								} else {
 									processType = true;
+									result.addDebug(null, 20345, typeCi.name(), excludeDataTypeRegex, PARAM_FLATTEN_DATATYPES_EXCLUDE_REGEX);
 								}
 
 							} else {
@@ -3552,8 +3560,10 @@ public class Flattener implements Transformer {
 
 								if (m.matches()) {
 									processType = true;
+									result.addInfo(null, 20344, typeCi.name(), includeObjectTypeRegex, PARAM_FLATTEN_OBJECT_TYPES_INCLUDE_REGEX);
 								} else {
 									processType = false;
+									result.addInfo(null, 20345, typeCi.name(), includeObjectTypeRegex, PARAM_FLATTEN_OBJECT_TYPES_INCLUDE_REGEX);
 								}
 
 							} else {
@@ -5086,10 +5096,11 @@ public class Flattener implements Transformer {
 		Matcher m = regex.matcher(genCi.name());
 
 		if (m.matches()) {
-
+			result.addDebug(null, 20344, genCi.name(), regex.pattern(), PARAM_INHERITANCE_INCLUDE_REGEX);
 			return true;
 
 		} else {
+			result.addDebug(null, 20345, genCi.name(), regex.pattern(), PARAM_INHERITANCE_INCLUDE_REGEX);
 
 			GenericModel model = genCi.model();
 
@@ -6030,6 +6041,9 @@ public class Flattener implements Transformer {
 				if (matcher.matches()) {
 
 					genPisToRemove.add(genPi);
+					result.addDebug(null, 20344, genPi.inClass().name(), regex, PARAM_OBJECT_TO_FEATURE_TYPE_NAV_REGEX);
+				} else {
+					result.addDebug(null, 20345, genPi.inClass().name(), regex, PARAM_OBJECT_TO_FEATURE_TYPE_NAV_REGEX);
 				}
 			}
 		}


### PR DESCRIPTION
Log messages in the Flattener are useful when using regular expressions, to make it easier for users to discover possible typos or other mistakes in these regular expressions.