### PR TITLE
Update SdoDimArrayExpression.toString()

### DIFF
--- a/src/main/java/de/interactive_instruments/ShapeChange/Target/SQL/expressions/SdoDimArrayExpression.java
+++ b/src/main/java/de/interactive_instruments/ShapeChange/Target/SQL/expressions/SdoDimArrayExpression.java
@@ -62,7 +62,7 @@ public class SdoDimArrayExpression implements Expression {
 	public void setElements(List<SdoDimElement> elements) {
 		this.elements = elements;
 	}
-	
+
 	public void addElement(SdoDimElement sde) {
 		this.elements.add(sde);
 	}
@@ -79,21 +79,13 @@ public class SdoDimArrayExpression implements Expression {
 
 		sb.append("MDSYS.SDO_DIM_ARRAY(");
 		if (hasElements()) {
-			
-			for(Iterator<SdoDimElement> iter = getElements().iterator(); iter.hasNext();) {
-				
+
+			for (Iterator<SdoDimElement> iter = getElements().iterator(); iter.hasNext();) {
+
 				SdoDimElement sde = iter.next();
-				sb.append("MDSYS.SDO_DIM_ELEMENT('");
-				sb.append(sde.getDimName());
-				sb.append("', ");
-				sb.append(sde.getLowerBound());
-				sb.append(", ");
-				sb.append(sde.getUpperBound());
-				sb.append(", ");
-				sb.append(sde.getTolerance());
-				sb.append(")");
-				
-				if(iter.hasNext()) {
+				sb.append(sde.toString());
+
+				if (iter.hasNext()) {
 					sb.append(", ");
 				}
 			}
@@ -104,4 +96,5 @@ public class SdoDimArrayExpression implements Expression {
 
 		return sb.toString();
 	}
+
 }

--- a/src/main/java/de/interactive_instruments/ShapeChange/Target/SQL/expressions/SdoDimElement.java
+++ b/src/main/java/de/interactive_instruments/ShapeChange/Target/SQL/expressions/SdoDimElement.java
@@ -102,4 +102,19 @@ public class SdoDimElement {
 	public void setTolerance(String tolerance) {
 		this.tolerance = tolerance;
 	}
+
+	@Override
+	public String toString() {
+		StringBuffer sb = new StringBuffer();
+		sb.append("MDSYS.SDO_DIM_ELEMENT('");
+		sb.append(this.getDimName());
+		sb.append("', ");
+		sb.append(this.getLowerBound());
+		sb.append(", ");
+		sb.append(this.getUpperBound());
+		sb.append(", ");
+		sb.append(this.getTolerance());
+		sb.append(")");
+		return sb.toString();
+	}
 }


### PR DESCRIPTION
Move the creation of the string representation of an SdoDimElement to SdoDimElement itself, instead of having it inside SdoDimArrayExpression.