### PR TITLE
Add log statements when connecting to and reading an eap-file

### DIFF
--- a/src/main/java/de/interactive_instruments/ShapeChange/Model/EA/EADocument.java
+++ b/src/main/java/de/interactive_instruments/ShapeChange/Model/EA/EADocument.java
@@ -134,6 +134,7 @@ public class EADocument extends ModelImpl implements Model {
 		
 		/* Connect to EA repository */
 		repository = new Repository();
+		r.addInfo(null, 43, connectionString);
 
 		if (!repository.OpenFile2(connectionString,
 				username, password)) {
@@ -142,8 +143,9 @@ public class EADocument extends ModelImpl implements Model {
 					repositoryFileNameOrConnectionString, username, password);
 			throw new ShapeChangeAbortException();
 		}
+		r.addInfo(null, 44, connectionString);
 
-		executeCommonInitializationProcedure();
+		executeCommonInitializationProcedure(r);
 	}
 
 	/** Connect to EA Repository without security information */
@@ -164,14 +166,16 @@ public class EADocument extends ModelImpl implements Model {
 
 		/** Connect to EA Repository */
 		repository = new Repository();
+		r.addInfo(null, 43, connectionString);
 
 		if (!repository.OpenFile(connectionString)) {
 			String errormsg = repository.GetLastError();
 			r.addFatalError(null, 30, errormsg, connectionString);
 			throw new ShapeChangeAbortException();
 		}
+		r.addInfo(null, 44, connectionString);
 
-		executeCommonInitializationProcedure();
+		executeCommonInitializationProcedure(r);
 	}
 
 	/**
@@ -222,9 +226,9 @@ public class EADocument extends ModelImpl implements Model {
 		}
 	}
 
-	public void executeCommonInitializationProcedure()
+	private void executeCommonInitializationProcedure(ShapeChangeResult r)
 			throws ShapeChangeAbortException {
-
+		r.addInfo(null, 45, repository.GetConnectionString());
 		// determine if specific packages should not be loaded
 		this.excludedPackageNames = options.getExcludedPackages();
 
@@ -416,7 +420,7 @@ public class EADocument extends ModelImpl implements Model {
 						escapeFileName(tmpDir.getName()), pi);
 			}
 		}
-
+		r.addInfo(null, 46, repository.GetConnectionString());
 	} // EA Document Ctor
 
 	/**

--- a/src/main/java/de/interactive_instruments/ShapeChange/ShapeChangeResult.java
+++ b/src/main/java/de/interactive_instruments/ShapeChange/ShapeChangeResult.java
@@ -586,7 +586,7 @@ public class ShapeChangeResult {
 		case 18:
 			return "Unsupported Java version: '$1$'. Java 1.6 or higher required.";
 		case 19:
-			return "Model object could not be instaniated: '$1$'.";
+			return "Model object could not be instantiated: '$1$'.";
 		case 20:
 			return "Model object could not be accessed: '$1$'.";
 		case 21:
@@ -631,6 +631,14 @@ public class ShapeChangeResult {
 			return "Microsoft Access Database file named '$1$' not found";
 		case 42:
 			return "Error reading from Microsoft Access Database '$2$'.  Error message is: '$1$'";
+		case 43:
+			return "Connecting to $1$";
+		case 44:
+			return "Connected to $1$";
+		case 45:
+			return "Starting reading $1$";
+		case 46:
+			return "Finished reading $1$";
 
 		case 100:
 			return "??The '$1$' with ID '$2$' has no name. The ID is used instead.";


### PR DESCRIPTION
Add log statements to indicate that ShapeChange is (1) connecting to
, (2) has connected, (3) is reading and (4) has read an eap-file. This
information is useful as it can take quite some time to do this, and
gives some information to the user as to what ShapeChange is doing.

A log file will then look as follows:
I ---------- Semantic validation of ShapeChange configuration: START ----------
I <...>
I ---------- Semantic validation of ShapeChange configuration: COMPLETE ----------
I Connecting to pathToFolder\fileName.eap
I Connected to pathToFolder\fileName.eap
I Starting reading pathToFolder\fileName.eap
I Finished reading pathToFolder\fileName.eap
I (Converter.java) Now processing transformation '<...>' for input ID: 'INPUT'.