### PR TITLE
Add error message when a default encoding rule is specified but not configured

### DIFF
--- a/src/main/java/de/interactive_instruments/ShapeChange/Model/InfoImpl.java
+++ b/src/main/java/de/interactive_instruments/ShapeChange/Model/InfoImpl.java
@@ -823,6 +823,9 @@ public abstract class InfoImpl implements Info {
 		}
 		if (s != null)
 			s = s.toLowerCase();
+		if (!options().encRuleExists(s)) {
+			result().addError(null, 181, s, platform);
+		}
 		return s;
 	}
 

--- a/src/main/java/de/interactive_instruments/ShapeChange/Options.java
+++ b/src/main/java/de/interactive_instruments/ShapeChange/Options.java
@@ -1164,6 +1164,14 @@ public class Options {
 	protected String extendsEncRule(String rule1) {
 		return fExtendsEncRule.get(rule1.toLowerCase());
 	}
+	
+	public boolean encRuleExists(String encRule) {
+		if ("*".equals(encRule)) {
+			return true;
+		} else {
+			return fExtendsEncRule.containsKey(encRule);
+		}
+	}
 
 	protected void addPackage(String k1, String s1, String s2, String s3,
 			String s4) {

--- a/src/main/java/de/interactive_instruments/ShapeChange/ShapeChangeResult.java
+++ b/src/main/java/de/interactive_instruments/ShapeChange/ShapeChangeResult.java
@@ -784,6 +784,8 @@ public class ShapeChangeResult {
 			return "??'$1$' is a type of an unsupported category for a qualifier. 'string' is used instead.";
 		case 180:
 			return "Could not find a map entry for the value type '$1$' of property '$2$' or the value type itself (in the model). Thus, constraining facets could not be created.";
+		case 181:
+			return "??Encoding rule $1$ is specified as default encoding rule for platform $2$ but is not configured.";
 			
 		case 200:
 			return "??Tagged value '$1$' missing in class '$2$'.";


### PR DESCRIPTION
Add an error message in the result when a default encoding rule is specified
for a certain platform but this default encoding rule is not present in the ShapeChange
configuration. This adds useful information for the user, as this misconfiguraton
likely will result in other errors or issues later on.