### PR TITLE
Fix configuration loading of the process mode of targets

### DIFF
--- a/src/main/java/de/interactive_instruments/ShapeChange/Converter.java
+++ b/src/main/java/de/interactive_instruments/ShapeChange/Converter.java
@@ -583,7 +583,7 @@ public class Converter {
 					.selectedSchemas();
 
 			String classname = tgt.getClassName();
-			String tmode = options.targetMode(classname);
+			ProcessMode tmode = options.targetMode(classname);
 			Class theClass = Class.forName(classname);
 			boolean targetCalled = false;
 
@@ -808,7 +808,7 @@ public class Converter {
 			target = (Target) theClass.newInstance();
 
 			if (target != null) {
-				String tmode = options.targetMode(classname);
+				ProcessMode tmode = options.targetMode(classname);
 				if (tmode.equals(ProcessMode.disabled))
 					continue;
 

--- a/src/main/java/de/interactive_instruments/ShapeChange/Model/InfoImpl.java
+++ b/src/main/java/de/interactive_instruments/ShapeChange/Model/InfoImpl.java
@@ -41,6 +41,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import de.interactive_instruments.ShapeChange.Options;
+import de.interactive_instruments.ShapeChange.ProcessMode;
 import de.interactive_instruments.ShapeChange.ShapeChangeResult.MessageContext;
 import de.interactive_instruments.ShapeChange.Model.EA.EADocument;
 import de.interactive_instruments.ShapeChange.Model.Generic.GenericModel;
@@ -855,13 +856,13 @@ public abstract class InfoImpl implements Info {
 		 */
 		if (ra[0].equals("rule") && !ra[1].equals("all")) {
 			if (!options().targetMode(options().targetClassName(rule))
-					.equals("enabled"))
+					.equals(ProcessMode.enabled))
 				return false;
 		}
 
 		if (ra[0].matches("re[cq]") && !ra[1].equals("all")) {
 			if (options().targetMode(options().targetClassName(rule))
-					.equals("disabled"))
+					.equals(ProcessMode.disabled))
 				return false;
 		}
 

--- a/src/main/java/de/interactive_instruments/ShapeChange/Options.java
+++ b/src/main/java/de/interactive_instruments/ShapeChange/Options.java
@@ -332,10 +332,11 @@ public class Options {
 	/**
 	 * Map of targets to generate from the input model. Keys are the names of
 	 * the Java classes which must implement the Target interface and values are
-	 * the requested processing modes, one of "enabled", "disabled",
-	 * "diagnostics-only".
+	 * the requested processing modes.
+	 * 
+	 * @see ProcessMode
 	 */
-	protected HashMap<String, String> fTargets = new HashMap<String, String>();
+	protected HashMap<String, ProcessMode> fTargets = new HashMap<String, ProcessMode>();
 
 	/** Hash table for additional parameters */
 	protected HashMap<String, String> fParameters = new HashMap<String, String>();
@@ -791,7 +792,7 @@ public class Options {
 		return me;
 	}
 
-	protected void addTarget(String k1, String k2) {
+	protected void addTarget(String k1, ProcessMode k2) {
 		fTargets.put(k1, k2);
 	}
 
@@ -803,18 +804,19 @@ public class Options {
 		return res;
 	}
 
-	public String targetMode(String tn) {
-		if (tn == null)
-			return "disabled";
-
-		String s = fTargets.get(tn);
-		if (s == null)
-			return "disabled";
-
-		return s;
+	public ProcessMode targetMode(String targetClassName) {
+		ProcessMode processMode;
+		if (targetClassName == null) {
+			processMode = ProcessMode.disabled;
+		} else if (fTargets.get(targetClassName) == null) {
+			processMode = ProcessMode.disabled;
+		} else {
+			processMode = fTargets.get(targetClassName);
+		}
+		return processMode;
 	}
 
-	public String setTargetMode(String tn, String mode) {
+	public ProcessMode setTargetMode(String tn, ProcessMode mode) {
 		return fTargets.put(tn, mode);
 	}
 
@@ -1520,7 +1522,7 @@ public class Options {
 
 				// System.out.println(tgtConfig);
 				String className = tgtConfig.getClassName();
-				String mode = tgtConfig.getProcessMode().name();
+				ProcessMode mode = tgtConfig.getProcessMode();
 
 				// set targets and their mode; if a target occurs multiple
 				// times, keep the enabled one(s)

--- a/src/test/java/de/interactive_instruments/ShapeChange/BasicTest.java
+++ b/src/test/java/de/interactive_instruments/ShapeChange/BasicTest.java
@@ -131,8 +131,9 @@ public abstract class BasicTest {
 	 * input).
 	 * 
 	 * @param config
+	 * @return result of ShapeChange, can be used to inspect e.g. the options object in it
 	 */
-	protected void execute(String config) {
+	protected ShapeChangeResult execute(String config) {
 
 		long start = (new Date()).getTime();
 		TestInstance test = new TestInstance(config);
@@ -142,6 +143,7 @@ public abstract class BasicTest {
 		assertTrue("Test model execution failed", test.noError());
 		if (testTime)
 			assertTrue("Execution time too long", end - start < 90000);
+		return test.result;
 	}
 
 	/**

--- a/src/test/java/de/interactive_instruments/ShapeChange/TargetModeTest.java
+++ b/src/test/java/de/interactive_instruments/ShapeChange/TargetModeTest.java
@@ -1,0 +1,15 @@
+package de.interactive_instruments.ShapeChange;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class TargetModeTest extends BasicTest {
+
+	@Test
+	public void test() {
+		ShapeChangeResult result = execute("src/test/resources/config/testXMI_targetMode.xml");
+		assertEquals("Target must be configured as enabled if the target is configured multiple times and one or more of its occurrences are enabled", ProcessMode.enabled, result.options().targetMode(Options.TargetXmlSchemaClass));
+	}
+
+}

--- a/src/test/resources/config/testXMI_targetMode.xml
+++ b/src/test/resources/config/testXMI_targetMode.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ShapeChangeConfiguration xmlns:xi="http://www.w3.org/2001/XInclude" xmlns="http://www.interactive-instruments.de/ShapeChange/Configuration/1.1" xmlns:sc="http://www.interactive-instruments.de/ShapeChange/Configuration/1.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.interactive-instruments.de/ShapeChange/Configuration/1.1 http://shapechange.net/resources/schema/ShapeChangeConfiguration.xsd">
+	<input>
+		<xi:include href="http://shapechange.net/resources/config/StandardAliases.xml"/>
+	</input>
+	<targets>
+		<TargetXmlSchema class="de.interactive_instruments.ShapeChange.Target.XmlSchema.XmlSchema" mode="disabled">
+			<xi:include href="http://shapechange.net/resources/config/StandardNamespaces.xml"/>
+			<xi:include href="http://shapechange.net/resources/config/StandardMapEntries.xml"/>
+			<xsdMapEntries>
+				<XsdMapEntry type="URI" xsdEncodingRules="iso19136_2007" xmlPropertyType="anyURI" xmlType="anyURI" xmlTypeType="simple" xmlTypeContent="simple"/>
+			</xsdMapEntries>
+		</TargetXmlSchema>
+	</targets>
+	<targets>
+		<TargetXmlSchema class="de.interactive_instruments.ShapeChange.Target.XmlSchema.XmlSchema" mode="enabled">
+			<xi:include href="http://shapechange.net/resources/config/StandardNamespaces.xml"/>
+			<xi:include href="http://shapechange.net/resources/config/StandardMapEntries.xml"/>
+			<xsdMapEntries>
+				<XsdMapEntry type="URI" xsdEncodingRules="iso19136_2007" xmlPropertyType="anyURI" xmlType="anyURI" xmlTypeType="simple" xmlTypeContent="simple"/>
+			</xsdMapEntries>
+		</TargetXmlSchema>
+	</targets>
+</ShapeChangeConfiguration>


### PR DESCRIPTION
A target must appear in the configuration as enabled if the target is
configured multiple times and one or more of its occurrences are
enabled. Otherwise the rule matching can give wrong results.