### PR TITLE
Update namespace handling ReplicationSchema

### DIFF
--- a/src/main/java/de/interactive_instruments/ShapeChange/Target/SQL/ReplicationSchemaVisitor.java
+++ b/src/main/java/de/interactive_instruments/ShapeChange/Target/SQL/ReplicationSchemaVisitor.java
@@ -270,15 +270,15 @@ public class ReplicationSchemaVisitor
 						// get enumeration class
 						ClassInfo enumeration = getValueType(propForColumn);
 
-						// if (enumeration != null) {
-
-						type = enumeration.qname() + "Type";
 
 						/*
 						 * Enumerations may reside in another namespace, they
 						 * are usually not flattened
 						 */
-						if (!model.isInSelectedSchemas(enumeration)) {
+						if (model.isInSelectedSchemas(enumeration)) {
+							type = SqlDdl.repSchemaTargetXmlns + ":" + enumeration.name() + "Type";
+						} else {
+							type = enumeration.qname() + "Type";
 							repSchemaPackagesForImport.add(enumeration.pkg());
 						}
 

--- a/src/main/java/de/interactive_instruments/ShapeChange/Target/SQL/SqlDdl.java
+++ b/src/main/java/de/interactive_instruments/ShapeChange/Target/SQL/SqlDdl.java
@@ -51,6 +51,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.xml.serializer.OutputPropertiesFactory;
 import org.apache.xml.serializer.Serializer;
 import org.apache.xml.serializer.SerializerFactory;
@@ -574,22 +575,29 @@ public class SqlDdl implements SingleTarget, MessageSource {
 						ReplicationSchemaConstants.DEFAULT_TARGET_NAMESPACE_SUFFIX,
 						false, true);
 				
-				repSchemaTargetNamespace = options.parameterAsString(
-						this.getClass().getName(),
-						ReplicationSchemaConstants.PARAM_TARGET_NAMESPACE,
-						schema.targetNamespace() == null ? "" : schema.targetNamespace(),
-						true, true);
-				repSchemaTargetVersion = options.parameterAsString(
-						this.getClass().getName(),
-						ReplicationSchemaConstants.PARAM_TARGET_VERSION,
-						schema.version() == null ? "" : schema.version(),
-						true, true);
-				repSchemaTargetXmlns = options.parameterAsString(
-						this.getClass().getName(),
-						ReplicationSchemaConstants.PARAM_TARGET_XMLNS,
-						schema.xmlns() == null ? "" : schema.xmlns(),
-						true, true);
-
+				String mainSchemaName = options.parameterAsString(this.getClass().getName(),
+						"replicationSchemaMainAppSchema", "", false, true);
+				if (StringUtils.isNotBlank(mainSchemaName)) {
+					for (PackageInfo packageInfo : model.selectedSchemas()) {
+						if (packageInfo.name().equals(mainSchemaName)) {
+							repSchemaTargetNamespace = packageInfo.targetNamespace();
+							repSchemaTargetVersion = packageInfo.version();
+							repSchemaTargetXmlns = packageInfo.xmlns();
+						}
+					}
+				} else {
+					repSchemaTargetNamespace = options.parameterAsString(this.getClass().getName(),
+							ReplicationSchemaConstants.PARAM_TARGET_NAMESPACE, schema.targetNamespace(), true, true);
+					repSchemaTargetVersion = options.parameterAsString(this.getClass().getName(),
+							ReplicationSchemaConstants.PARAM_TARGET_VERSION, schema.version(), true, true);
+					repSchemaTargetXmlns = options.parameterAsString(this.getClass().getName(),
+							ReplicationSchemaConstants.PARAM_TARGET_XMLNS, schema.xmlns(), true, true);
+				}
+				// make sure parameters are never null
+				repSchemaTargetNamespace = StringUtils.defaultString(repSchemaTargetNamespace);
+				repSchemaTargetVersion = StringUtils.defaultString(repSchemaTargetVersion);
+				repSchemaTargetXmlns = StringUtils.defaultString(repSchemaTargetXmlns);
+				
 				repSchemaDocumentationUnlimitedLengthCharacterDataType = options
 						.parameterAsString(this.getClass().getName(),
 								ReplicationSchemaConstants.PARAM_DOCUMENTATION_UNLIMITEDLENGTHCHARACTERDATATYPE,


### PR DESCRIPTION
Add the possiblity to select a schema whose namespace settings should be
used in the replication schema generation. This functionality is needed
after the conversion of the SqlDdl target to a single target.

Make sure that the reference to a simple type representing an
enumeration uses the correct namespace abbreviation.