### PR TITLE
New classes in package Target are not ignored

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,7 @@
 .DS_Store
 
 # Maven
-target/
+/target/
 
 # Tests
 testResults/


### PR DESCRIPTION
New files, such as Java classes in package Target or one of its
subpackages are not ignored anymore by git.

Before: git check-ignore -v src/main/java/de/interactive_instruments/ShapeChange/Target/NewClass.java
.gitignore:15:target/   src/main/java/de/interactive_instruments/ShapeChange/Target/NewClass.java

After: git check-ignore -v src/main/java/de/interactive_instruments/ShapeChange/Target/NewClass.java
(no output, thus this path is not ignored)