### PR TITLE
validateStereotypesCache() for EA models

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .classpath
 .project
 .settings/
+.eclipse-pmd
 
 # Intellij
 .idea/

--- a/src/main/java/de/interactive_instruments/ShapeChange/Model/EA/AssociationInfoEA.java
+++ b/src/main/java/de/interactive_instruments/ShapeChange/Model/EA/AssociationInfoEA.java
@@ -48,6 +48,7 @@ import de.interactive_instruments.ShapeChange.Model.Descriptor;
 import de.interactive_instruments.ShapeChange.Model.LangString;
 import de.interactive_instruments.ShapeChange.Model.Model;
 import de.interactive_instruments.ShapeChange.Model.PropertyInfo;
+import de.interactive_instruments.ShapeChange.Util.ea.EAGeneralUtil;
 
 public class AssociationInfoEA extends AssociationInfoImpl
 		implements AssociationInfo {
@@ -295,27 +296,16 @@ public class AssociationInfoEA extends AssociationInfoImpl
 		return document.result;
 	} // result()
 
-	// Validate stereotypes cache of the association. The stereotypes found are
-	// 1. restricted to those defined within ShapeChange and 2. deprecated ones
-	// are normalized to the lastest definitions.
+	/**
+	 * The stereotypes added to the cache are the well-known equivalents of the
+	 * stereotypes defined in the EA model, if mapped in the configuration.
+	 * 
+	 * @see de.interactive_instruments.ShapeChange.Model.Info#validateStereotypesCache()
+	 */
 	public void validateStereotypesCache() {
 		if (stereotypesCache == null) {
-			// Fetch stereotypes 'collection' ...
-			String sts = eaConnector.GetStereotypeEx();
-			String[] stereotypes = sts.split("\\,");
-			// Allocate cache
-			stereotypesCache = options().stereotypesFactory();
-			// Copy stereotypes found for connector selecting those defined in
-			// ShapeChange and normalizing deprecated ones.
-			for (String stereotype : stereotypes) {
-				String st = document.options
-						.normalizeStereotype(stereotype.trim());
-				if (st != null)
-					for (String s : Options.assocStereotypes) {
-						if (st.toLowerCase().equals(s))
-							stereotypesCache.add(s);
-					}
-			}
+			stereotypesCache = EAGeneralUtil.createAndPopulateStereotypeCache(
+					eaConnector.GetStereotypeEx(), Options.assocStereotypes, this);
 		}
 	} // validateStereotypesCache()
 	

--- a/src/main/java/de/interactive_instruments/ShapeChange/Model/EA/ClassInfoEA.java
+++ b/src/main/java/de/interactive_instruments/ShapeChange/Model/EA/ClassInfoEA.java
@@ -62,6 +62,7 @@ import de.interactive_instruments.ShapeChange.Model.Model;
 import de.interactive_instruments.ShapeChange.Model.OperationInfo;
 import de.interactive_instruments.ShapeChange.Model.PackageInfo;
 import de.interactive_instruments.ShapeChange.Model.PropertyInfo;
+import de.interactive_instruments.ShapeChange.Util.ea.EAGeneralUtil;
 
 public class ClassInfoEA extends ClassInfoImpl implements ClassInfo {
 
@@ -572,40 +573,18 @@ public class ClassInfoEA extends ClassInfoImpl implements ClassInfo {
 		return null;
 	} // property()
 
-	// Validate stereotypes cache of the class. The stereotypes found are 1.
-	// restricted to those defined within ShapeChange and 2. deprecated ones
-	// are normalized to the lastest definitions.
+	/**
+	 * The stereotypes added to the cache are the well-known equivalents of the
+	 * stereotypes defined in the EA model, if mapped in the configuration.
+	 * 
+	 * @see de.interactive_instruments.ShapeChange.Model.Info#validateStereotypesCache()
+	 */
 	public void validateStereotypesCache() {
 
 		if (stereotypesCache == null) {
-
-			// Fetch stereotypes 'collection' ...
-			String sts = eaClassElement.GetStereotypeEx();
-			document.result.addDebug(null, 50, name(), sts);
-			String[] stereotypes = sts.split("\\,");
-
-			// Allocate cache
-			stereotypesCache = options().stereotypesFactory();
-			// Copy stereotypes found in class selecting those defined in
-			// ShapeChange and normalizing deprecated ones.
-			for (String stereotype : stereotypes) {
-				String st = document.options
-						.normalizeStereotype(stereotype.trim());
-				if (st != null) {
-					document.result.addDebug(null, 51, name(), stereotype, st);
-					boolean wellKnownStereotypeFound = false;
-					for (String s : Options.classStereotypes) {
-						if (st.toLowerCase().equals(s)) {
-							stereotypesCache.add(s);
-							document.result.addDebug(null, 52, name(), s);
-							wellKnownStereotypeFound = true;
-						}
-					}
-					if (!wellKnownStereotypeFound) {
-						document.result.addDebug(null, 53, name(), st);
-					}
-				}
-			}
+			stereotypesCache = EAGeneralUtil.createAndPopulateStereotypeCache(
+					eaClassElement.GetStereotypeEx(), Options.classStereotypes,
+					this);
 
 			/*
 			 * 2017-03-23 JE: Apparently when calling
@@ -625,7 +604,7 @@ public class ClassInfoEA extends ClassInfoImpl implements ClassInfo {
 			if (!stereotypesCache.contains("enumeration") && eaClassElement
 					.GetType().equalsIgnoreCase("enumeration")) {
 				stereotypesCache.add("enumeration");
-				document.result.addDebug(null, 52, name(), "enumeration");
+				document.result.addDebug(null, 52, this.name(), "enumeration");
 			}
 			/*
 			 * The same reasoning applies for data types, which are not classes 
@@ -634,8 +613,11 @@ public class ClassInfoEA extends ClassInfoImpl implements ClassInfo {
 			if (!stereotypesCache.contains("datatype") && eaClassElement
 					.GetType().equalsIgnoreCase("datatype")) {
 				stereotypesCache.add("datatype");
-				document.result.addDebug(null, 52, name(), "datatype");
+				document.result.addDebug(null, 52, this.name(), "datatype");
 			}
+			document.result.addDebug(null, 55, this.name(),
+					Integer.toString(stereotypesCache.size()),
+					stereotypesCache.toString());
 		}
 	} // validateStereotypesCache()
 

--- a/src/main/java/de/interactive_instruments/ShapeChange/Model/EA/OperationInfoEA.java
+++ b/src/main/java/de/interactive_instruments/ShapeChange/Model/EA/OperationInfoEA.java
@@ -48,6 +48,7 @@ import de.interactive_instruments.ShapeChange.Model.LangString;
 import de.interactive_instruments.ShapeChange.Model.Model;
 import de.interactive_instruments.ShapeChange.Model.OperationInfo;
 import de.interactive_instruments.ShapeChange.Model.OperationInfoImpl;
+import de.interactive_instruments.ShapeChange.Util.ea.EAGeneralUtil;
 
 public class OperationInfoEA extends OperationInfoImpl
 		implements OperationInfo {
@@ -227,28 +228,16 @@ public class OperationInfoEA extends OperationInfoImpl
 		return document.result;
 	} // result()
 
-	// Validate stereotypes cache of the property. The stereotypes found are 1.
-	// restricted to those defined within ShapeChange and 2. deprecated ones
-	// are normalized to the lastest definitions.
+	/**
+	 * The stereotypes added to the cache are the well-known equivalents of the
+	 * stereotypes defined in the EA model, if mapped in the configuration.
+	 * 
+	 * @see de.interactive_instruments.ShapeChange.Model.Info#validateStereotypesCache()
+	 */
 	public void validateStereotypesCache() {
 		if (stereotypesCache == null) {
-			// Fetch stereotypes 'collection' ...
-			String sts;
-			sts = eaMethod.GetStereotypeEx();
-			String[] stereotypes = sts.split("\\,");
-			// Allocate cache
-			stereotypesCache = options().stereotypesFactory();
-			// Copy stereotypes found in property selecting those defined in
-			// ShapeChange and normalizing deprecated ones.
-			for (String stereotype : stereotypes) {
-				String st = document.options
-						.normalizeStereotype(stereotype.trim());
-				if (st != null)
-					for (String s : Options.propertyStereotypes) {
-						if (st.toLowerCase().equals(s))
-							stereotypesCache.add(s);
-					}
-			}
+			stereotypesCache = EAGeneralUtil.createAndPopulateStereotypeCache(
+					eaMethod.GetStereotypeEx(), Options.propertyStereotypes, this);
 		}
 	} // validateStereotypesCache()
 

--- a/src/main/java/de/interactive_instruments/ShapeChange/Model/EA/PackageInfoEA.java
+++ b/src/main/java/de/interactive_instruments/ShapeChange/Model/EA/PackageInfoEA.java
@@ -43,12 +43,13 @@ import org.sparx.TaggedValue;
 
 import de.interactive_instruments.ShapeChange.Options;
 import de.interactive_instruments.ShapeChange.ShapeChangeResult;
+import de.interactive_instruments.ShapeChange.ShapeChangeResult.MessageContext;
 import de.interactive_instruments.ShapeChange.Model.Descriptor;
 import de.interactive_instruments.ShapeChange.Model.LangString;
 import de.interactive_instruments.ShapeChange.Model.Model;
 import de.interactive_instruments.ShapeChange.Model.PackageInfo;
 import de.interactive_instruments.ShapeChange.Model.PackageInfoImpl;
-import de.interactive_instruments.ShapeChange.ShapeChangeResult.MessageContext;
+import de.interactive_instruments.ShapeChange.Util.ea.EAGeneralUtil;
 
 public class PackageInfoEA extends PackageInfoImpl implements PackageInfo {
 
@@ -168,27 +169,16 @@ public class PackageInfoEA extends PackageInfoImpl implements PackageInfo {
 		return (TreeSet<PackageInfo>) childPI.clone();
 	} // containedPackages()
 
-	// Validate stereotypes cache of the package. The stereotypes found are 1.
-	// restricted to those defined within ShapeChange and 2. deprecated ones
-	// are normalized to the lastest definitions.
+	/**
+	 * The stereotypes added to the cache are the well-known equivalents of the
+	 * stereotypes defined in the EA model, if mapped in the configuration.
+	 * 
+	 * @see de.interactive_instruments.ShapeChange.Model.Info#validateStereotypesCache()
+	 */
 	public void validateStereotypesCache() {
 		if (stereotypesCache == null) {
-			// Fetch stereotypes 'collection' ...
-			String sts = eaPackage.GetStereotypeEx();
-			String[] stereotypes = sts.split("\\,");
-			// Allocate cache
-			stereotypesCache = options().stereotypesFactory();
-			// Copy stereotypes found in package selecting those defined in
-			// ShapeChange and normalizing deprecated ones.
-			for (String stereotype : stereotypes) {
-				String st = document.options
-						.normalizeStereotype(stereotype.trim());
-				if (st != null)
-					for (String s : Options.packageStereotypes) {
-						if (st.toLowerCase().equals(s))
-							stereotypesCache.add(s);
-					}
-			}
+			stereotypesCache = EAGeneralUtil.createAndPopulateStereotypeCache(
+					eaPackage.GetStereotypeEx(), Options.packageStereotypes, this);
 		}
 	} // validateStereotypesCache()
 

--- a/src/main/java/de/interactive_instruments/ShapeChange/Model/EA/PropertyInfoEA.java
+++ b/src/main/java/de/interactive_instruments/ShapeChange/Model/EA/PropertyInfoEA.java
@@ -47,6 +47,7 @@ import org.sparx.RoleTag;
 import de.interactive_instruments.ShapeChange.Multiplicity;
 import de.interactive_instruments.ShapeChange.Options;
 import de.interactive_instruments.ShapeChange.ShapeChangeResult;
+import de.interactive_instruments.ShapeChange.ShapeChangeResult.MessageContext;
 import de.interactive_instruments.ShapeChange.StructuredNumber;
 import de.interactive_instruments.ShapeChange.Type;
 import de.interactive_instruments.ShapeChange.Model.AssociationInfo;
@@ -58,7 +59,7 @@ import de.interactive_instruments.ShapeChange.Model.Model;
 import de.interactive_instruments.ShapeChange.Model.PropertyInfo;
 import de.interactive_instruments.ShapeChange.Model.PropertyInfoImpl;
 import de.interactive_instruments.ShapeChange.Model.Qualifier;
-import de.interactive_instruments.ShapeChange.ShapeChangeResult.MessageContext;
+import de.interactive_instruments.ShapeChange.Util.ea.EAGeneralUtil;
 
 public class PropertyInfoEA extends PropertyInfoImpl implements PropertyInfo {
 
@@ -664,31 +665,22 @@ public class PropertyInfoEA extends PropertyInfoImpl implements PropertyInfo {
 		return sequenceNumber;
 	} // sequenceNumber()
 
-	// Validate stereotypes cache of the property. The stereotypes found are 1.
-	// restricted to those defined within ShapeChange and 2. deprecated ones
-	// are normalized to the lastest definitions.
+	/**
+	 * The stereotypes added to the cache are the well-known equivalents of the
+	 * stereotypes defined in the EA model, if mapped in the configuration.
+	 * 
+	 * @see de.interactive_instruments.ShapeChange.Model.Info#validateStereotypesCache()
+	 */
 	public void validateStereotypesCache() {
 		if (stereotypesCache == null) {
-			// Fetch stereotypes 'collection' ...
-			String sts;
-			if (isAttribute())
-				sts = eaAttribute.GetStereotypeEx();
-			else
-				sts = eaConnectorEnd.GetStereotypeEx();
-			String[] stereotypes = sts.split("\\,");
-			// Allocate cache
-			stereotypesCache = options().stereotypesFactory();
-			// Copy stereotypes found in property selecting those defined in
-			// ShapeChange and normalizing deprecated ones.
-			for (String stereotype : stereotypes) {
-				String st = document.options
-						.normalizeStereotype(stereotype.trim());
-				if (st != null)
-					for (String s : Options.propertyStereotypes) {
-						if (st.toLowerCase().equals(s))
-							stereotypesCache.add(s);
-					}
+			String eaStereotypeEx;
+			if (isAttribute()) {
+				eaStereotypeEx = eaAttribute.GetStereotypeEx();
+			} else {
+				eaStereotypeEx = eaConnectorEnd.GetStereotypeEx();
 			}
+			stereotypesCache = EAGeneralUtil.createAndPopulateStereotypeCache(
+					eaStereotypeEx, Options.propertyStereotypes, this);
 		}
 	} // validateStereotypesCache()
 

--- a/src/main/java/de/interactive_instruments/ShapeChange/Model/Info.java
+++ b/src/main/java/de/interactive_instruments/ShapeChange/Model/Info.java
@@ -486,10 +486,13 @@ public interface Info extends Comparable<Info> {
 	public Map<String, String> taggedValues(String tagList);
 
 	/**
-	 * Create cache of stereotypes and tagged values
+	 * Validate cache of tagged values.
 	 */
 	public void validateTaggedValuesCache();
 
+	/**
+	 * Validate cache of stereotypes.
+	 */
 	public void validateStereotypesCache();
 
 	/**

--- a/src/main/java/de/interactive_instruments/ShapeChange/Options.java
+++ b/src/main/java/de/interactive_instruments/ShapeChange/Options.java
@@ -4017,7 +4017,10 @@ public class Options {
 		addRule("rule-ldp-cls-oneo-metadata");
 	}
 
-	/** Normalize a stereotype fetched from the model. */
+	/**
+	 * Normalize a stereotype fetched from the model. This includes trimming the
+	 * incoming stereotype and looking it up in the defined stereotype aliases.
+	 */
 	public String normalizeStereotype(String stereotype) {
 		// Map stereotype alias to well-known stereotype
 		String s = stereotypeAlias(stereotype.trim());

--- a/src/main/java/de/interactive_instruments/ShapeChange/ShapeChangeResult.java
+++ b/src/main/java/de/interactive_instruments/ShapeChange/ShapeChangeResult.java
@@ -734,13 +734,17 @@ public class ShapeChangeResult {
 			
 		
 		case 50:
-			return "Element '$1$' has the following stereotype(s): '$2$'.";
+			return "Element '$1$' has the following stereotype(s) in the input model: '$2$'.";
 		case 51:
 			return "Stereotype '$2$' of element '$1$' normalized to '$3$'.";
 		case 52:
 			return "Well-known stereotype '$2$' added to element '$1$'.";
 		case 53:
 			return "No well-known stereotype found for stereotype '$2$' of element '$1$', ignoring it.";
+		case 54:
+			return "Element '$1$' has $2$ well-known stereotype(s): '$3$'";
+		case 55:
+			return "After taking into account data types and enumerations modelled without the use of stereotypes is element '$1$' treated as having $2$ well-known stereotype(s): '$3$'";
 
 		case 100:
 			return "??The '$1$' with ID '$2$' has no name. The ID is used instead.";

--- a/src/main/java/de/interactive_instruments/ShapeChange/Util/ea/EAGeneralUtil.java
+++ b/src/main/java/de/interactive_instruments/ShapeChange/Util/ea/EAGeneralUtil.java
@@ -1,0 +1,39 @@
+package de.interactive_instruments.ShapeChange.Util.ea;
+
+import de.interactive_instruments.ShapeChange.Model.Info;
+import de.interactive_instruments.ShapeChange.Model.Stereotypes;
+
+public class EAGeneralUtil {
+
+	public static Stereotypes createAndPopulateStereotypeCache(
+			String eaStereotypeEx, String[] wellKnownStereotypes, Info info) {
+		info.result().addDebug(null, 50, info.name(), eaStereotypeEx);
+		Stereotypes stereotypesCache = info.options().stereotypesFactory();
+		String[] eaStereotypes = eaStereotypeEx.split("\\,");
+		for (String stereotype : eaStereotypes) {
+			String normalizedStereotype = info.options()
+					.normalizeStereotype(stereotype);
+			if (normalizedStereotype != null) {
+				info.result().addDebug(null, 51, info.name(), stereotype,
+						normalizedStereotype);
+				boolean wellKnownStereotypeFound = false;
+				for (String s : wellKnownStereotypes) {
+					if (normalizedStereotype.toLowerCase().equals(s)) {
+						stereotypesCache.add(s);
+						info.result().addDebug(null, 52, info.name(), s);
+						wellKnownStereotypeFound = true;
+					}
+				}
+				if (!wellKnownStereotypeFound) {
+					info.result().addDebug(null, 53, info.name(),
+							normalizedStereotype);
+				}
+			}
+		}
+		info.result().addDebug(null, 54, info.name(),
+				Integer.toString(stereotypesCache.size()),
+				stereotypesCache.toString());
+		return stereotypesCache;
+	}
+
+}


### PR DESCRIPTION
Update validateStereotypesCache() for EA models: refactor to remove duplicated code.