### PR TITLE
Ignore code list values in GeoPackage generation

### DIFF
--- a/src/main/java/de/interactive_instruments/ShapeChange/Target/GeoPackage/GeoPackageTemplate.java
+++ b/src/main/java/de/interactive_instruments/ShapeChange/Target/GeoPackage/GeoPackageTemplate.java
@@ -425,6 +425,11 @@ public class GeoPackageTemplate implements SingleTarget, MessageSource {
 		    // already encoded as data column constraints
 		    continue;
 		}
+		
+		if (ci.category() == Options.CODELIST) {
+			result.addWarning(this, 113, ci.name());
+			continue;
+		}
 
 		// class is a feature type, object type, or data type
 
@@ -955,6 +960,8 @@ public class GeoPackageTemplate implements SingleTarget, MessageSource {
 	    return "Property '$1$' of class '$2$' has tagged value gpkgZ with unrecognized value '$3$'. Using value defined by target parameter gpkgZ (which is '$4$').";
 	case 112:
 	    return "Property '$1$' of class '$2$' has tagged value gpkgM with unrecognized value '$3$'. Using value defined by target parameter gpkgM (which is '$4$').";
+	case 113:
+		return "Ignoring values in code list '$1$'. Encoding of code list values is currently not supported by the target.";
 
 	case 503:
 	    return "Output file '$1$' already exists in output directory ('$2$'). It will be deleted prior to processing.";


### PR DESCRIPTION
A code list can be modelled as having values in the UML model. Take
this into account by logging a warning ("not yet supported"),
ignoring the code list and continuing execution.