### PR TITLE
Suppress conversion only when tag gpkgEncodingRule = notEncoded

### DIFF
--- a/src/main/java/de/interactive_instruments/ShapeChange/Target/GeoPackage/GeoPackageTemplate.java
+++ b/src/main/java/de/interactive_instruments/ShapeChange/Target/GeoPackage/GeoPackageTemplate.java
@@ -361,7 +361,7 @@ public class GeoPackageTemplate implements SingleTarget, MessageSource {
 
     public static boolean isEncoded(Info i) {
 
-	if (i.matches(GeoPackageConstants.RULE_TGT_GPKG_ALL_NOTENCODED)) {
+	if (i.matches(GeoPackageConstants.RULE_TGT_GPKG_ALL_NOTENCODED) && i.encodingRule("gpkg").equalsIgnoreCase("notencoded")) {
 	    return false;
 	} else {
 	    return true;


### PR DESCRIPTION
Otherwise, all model elements are suppressed when rule `rule-gpkg-all-notEncoded` is enabled.