### PR TITLE
Gpkg improvements

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -181,7 +181,7 @@
 		<dependency>
 			<groupId>mil.nga.geopackage</groupId>
 			<artifactId>geopackage</artifactId>
-			<version>3.4.0</version>
+			<version>3.5.0</version>
 		</dependency>
 	</dependencies>
 	<url>http://shapechange.net/</url>

--- a/src/main/java/de/interactive_instruments/ShapeChange/Target/GeoPackage/GeoPackageConstants.java
+++ b/src/main/java/de/interactive_instruments/ShapeChange/Target/GeoPackage/GeoPackageConstants.java
@@ -71,10 +71,15 @@ public class GeoPackageConstants {
     public static final String PARAM_GPKGM = "gpkgM";
     public static final String PARAM_GPKGZ = "gpkgZ";
 
+    /**
+     * Whether or not spatial indexes should be created; default is 'false'.
+     */
+    public static final String PARAM_CREATE_SPATIAL_INDEXES = "createSpatialIndexes";
+    
     /* ------------------------ */
     /* --- Conversion rules --- */
     /* ------------------------ */
-
+    
     public static final String RULE_TGT_GPKG_CLS_OBJECTTYPE = "rule-gpkg-cls-objecttype";
 
     public static final String RULE_TGT_GPKG_ALL_NOTENCODED = "rule-gpkg-all-notEncoded";
@@ -86,5 +91,6 @@ public class GeoPackageConstants {
      * generated).
      */
     public static final String RULE_TGT_GPKG_CLS_IDENTIFIER_STEREOTYPE = "rule-gpkg-cls-identifierStereotype";
+    
 
 }

--- a/src/main/java/de/interactive_instruments/ShapeChange/Target/GeoPackage/GeoPackageTemplate.java
+++ b/src/main/java/de/interactive_instruments/ShapeChange/Target/GeoPackage/GeoPackageTemplate.java
@@ -69,6 +69,7 @@ import mil.nga.geopackage.core.srs.SpatialReferenceSystem;
 import mil.nga.geopackage.core.srs.SpatialReferenceSystemDao;
 import mil.nga.geopackage.db.GeoPackageDataType;
 import mil.nga.geopackage.extension.CrsWktExtension;
+import mil.nga.geopackage.extension.RTreeIndexExtension;
 import mil.nga.geopackage.features.columns.GeometryColumns;
 import mil.nga.geopackage.features.columns.GeometryColumnsDao;
 import mil.nga.geopackage.features.user.FeatureColumn;
@@ -399,6 +400,10 @@ public class GeoPackageTemplate implements SingleTarget, MessageSource {
 	    SpatialReferenceSystem srs = srsDao.getOrCreateCode(srsOrganization, organizationCoordSysId);
 
 	    ContentsDao contentsDao = geoPackage.getContentsDao();
+	    
+	    RTreeIndexExtension rTreeIndexExtension =  new RTreeIndexExtension(geoPackage);
+	    boolean createSpatialIndexes = options.parameterAsBoolean(this.getClass().getName(),
+			    GeoPackageConstants.PARAM_CREATE_SPATIAL_INDEXES, false);
 
 	    /*
 	     * Create data column constraints for enumerations.
@@ -594,6 +599,9 @@ public class GeoPackageTemplate implements SingleTarget, MessageSource {
 
 		    FeatureTable table = new FeatureTable(tableName, columns);
 		    geoPackage.createFeatureTable(table);
+		    if (createSpatialIndexes) {
+		    	rTreeIndexExtension.create(table);
+		    }
 
 		} else {
 

--- a/src/main/java/de/interactive_instruments/ShapeChange/Target/GeoPackage/GeoPackageTemplate.java
+++ b/src/main/java/de/interactive_instruments/ShapeChange/Target/GeoPackage/GeoPackageTemplate.java
@@ -646,7 +646,10 @@ public class GeoPackageTemplate implements SingleTarget, MessageSource {
     			}
 
     			contentsDao.create(contents);
+    			
     		}
+    		
+    		result.addResult(getTargetName(), outputDirectory, outputFilename, null);
 
     	} catch (SQLException e) {
     		result.addError(this, 108, e.getMessage());

--- a/src/main/java/de/interactive_instruments/ShapeChange/Target/GeoPackage/GeoPackageTemplateConfigurationValidator.java
+++ b/src/main/java/de/interactive_instruments/ShapeChange/Target/GeoPackage/GeoPackageTemplateConfigurationValidator.java
@@ -60,7 +60,7 @@ public class GeoPackageTemplateConfigurationValidator extends AbstractConfigurat
 	    Stream.of(GeoPackageConstants.PARAM_DOCUMENTATION_NOVALUE, GeoPackageConstants.PARAM_DOCUMENTATION_TEMPLATE,
 		    GeoPackageConstants.PARAM_GPKGM, GeoPackageConstants.PARAM_GPKGZ,
 		    GeoPackageConstants.PARAM_ID_COLUMN_NAME, GeoPackageConstants.PARAM_ORGANIZATION_COORD_SYS_ID,
-		    GeoPackageConstants.PARAM_SRS_ORGANIZATION).collect(Collectors.toSet()));
+		    GeoPackageConstants.PARAM_SRS_ORGANIZATION, GeoPackageConstants.PARAM_CREATE_SPATIAL_INDEXES).collect(Collectors.toSet()));
     protected List<Pattern> regexForAllowedParametersWithDynamicNames = null;
 
     // these fields will be initialized when isValid(...) is called


### PR DESCRIPTION
Improvements: see commit messages.

A note on the changes for `gpkg_data_columns`: the idea behind it is that it makes more sense to describe all columns instead of just using the columns that refer to enumerations. From the spec:

> The schema extension provides a means to describe the columns of tables in a GeoPackage with more detail than can be captured by the SQL table definition directly. The information provided by this extension can be used by applications to, for instance, present data contained in a GeoPackage in a more user-friendly fashion or implement data validation logic.

There is no hard enum validation in SQLite anyway - for that, check constraints should be used instead, I guess - the contents of the `gpkg_data_columns` and `gpkg_data_column_constraints` are mainly for use in applications on top of a GeoPackage.

I added indentation in method writeAll as it was rather hard to read otherwise, please [ignore whitespace](https://stackoverflow.com/questions/37007300/how-to-ignore-whitespace-in-github-when-comparing) when reviewing... sorry for that.