### PR TITLE
Describe use of java.library.path

### DIFF
--- a/src/docs/asciidoc/get started/Get_Started.adoc
+++ b/src/docs/asciidoc/get started/Get_Started.adoc
@@ -55,6 +55,8 @@ If you plan to process Enterprise Architect models, then the steps to do so depe
 
 NOTE: If you are searching for a 32bit JDK, take a look at the JDKs from https://adoptium.net/[Adoptium]. They provide 32bit OpenJDK for Java 8, 11, and later.
 
+NOTE: This step can be skipped if you set system property java.library.path every time you invoke ShapeChange: _java -Djava.library.path="<EA installation folder>\Java API" -jar ShapeChange-{project-version}.jar (options) modelfile_ This can be useful when you cannot copy the aforementioned dll files, e.g. because of missing administrator rights.
+
 The latest version of ShapeChange has been tested with the 64bit OpenJDK 11 from Adoptium (more precisely: its predecessor AdoptOpenJDK).
 
 |5 |If you plan to create

--- a/src/docs/asciidoc/get started/Typical_problems.adoc
+++ b/src/docs/asciidoc/get started/Typical_problems.adoc
@@ -59,7 +59,8 @@ Typically this is the reason for this error.
 SSJavaCOM.dll with the message: "no SSJavaCOM in java.library.path".
 |The SSJavaCOM.dll is not in a path known to the Java Virtual Machine
 you are executing, typically System32 or SysWOW64 depending on your
-operating system. Contact your system administrator, if you need help.
+operating system. Set system property java.library.path when invoking 
+ShapeChange, or contact your system administrator, if you need help.
 
 |An UnsatisfiedLinkError exception is raised when trying to load
 SSJavaCOM.dll with the message: "Can't load IA 32-bit .dll on a AMD


### PR DESCRIPTION
It is possible to use ShapeChange on EA files without having to copy SSJavaCOM64.dll or SSJavaCOM.dll to a folder that the Java Virtual Machine automatically searches when loading libraries.

See this post on the EA forum for more information: https://sparxsystems.com/forums/smf/index.php/topic,46812.msg273672.html.