### PR TITLE
build: make the Enterprise Architect module optional via an 'ea' profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,9 +43,35 @@
 
 	<modules>
 		<module>shapechange-core</module>
-		<module>shapechange-ea</module>
 		<module>shapechange-app</module>
 	</modules>
+
+	<profiles>
+		<!--
+			Enterprise Architect support. Active by default, so the standard build is
+			unchanged. The shapechange-ea module compiles against org.sparx:eaapi, which
+			ships with an Enterprise Architect installation and is not available from any
+			public repository, so a machine or CI runner without EA cannot build it.
+
+			Building with -DskipEa leaves out that module and the dependency on it,
+			producing a distribution that supports every non-EA input type (SCXML, XMI,
+			GCSR). EA model readers and the EA database-model writer are resolved by class
+			name at runtime (see DefaultModelProvider and SqlDdl), so nothing in
+			shapechange-core or shapechange-app references them at compile time.
+		-->
+		<profile>
+			<id>ea</id>
+			<activation>
+				<property>
+					<name>!skipEa</name>
+				</property>
+			</activation>
+			<modules>
+				<module>shapechange-ea</module>
+			</modules>
+		</profile>
+	</profiles>
+
 
 	<scm>
 		<url>https://github.com/ShapeChange/ShapeChange</url>

--- a/shapechange-app/pom.xml
+++ b/shapechange-app/pom.xml
@@ -15,11 +15,6 @@
 			<version>${project.version}</version>
 		</dependency>
 		<dependency>
-			<groupId>${project.groupId}</groupId>
-			<artifactId>shapechange-ea</artifactId>
-			<version>${project.version}</version>
-		</dependency>
-		<dependency>
 			<groupId>org.apache.xmlgraphics</groupId>
 			<artifactId>fop</artifactId>
 		</dependency>
@@ -58,17 +53,6 @@
 			</resource>
 			<resource>
 				<directory>../shapechange-core/src/main/resources</directory>
-				<filtering>true</filtering>
-				<targetPath>${project.basedir}/sc-resources</targetPath>
-				<includes>
-					<include>**/*</include>
-				</includes>
-				<excludes>
-					<exclude>*.properties</exclude>
-				</excludes>
-			</resource>
-			<resource>
-				<directory>../shapechange-ea/src/main/resources</directory>
 				<filtering>true</filtering>
 				<targetPath>${project.basedir}/sc-resources</targetPath>
 				<includes>
@@ -413,4 +397,46 @@
 			</extension>
 		</extensions>
 	</build>
+	<profiles>
+		<!--
+			Enterprise Architect support; see the 'ea' profile in the parent POM. Active by
+			default, so the standard build is unchanged. Disabled with -DskipEa, which drops the
+			dependency on shapechange-ea and its EA-only resources, letting this module build
+			without the proprietary org.sparx:eaapi artifact that ships with an Enterprise
+			Architect installation. Main.java references no EA type, and EA model readers are
+			resolved by class name at runtime (see DefaultModelProvider), so nothing here needs
+			EA at compile time.
+		-->
+		<profile>
+			<id>ea</id>
+			<activation>
+				<property>
+					<name>!skipEa</name>
+				</property>
+			</activation>
+			<dependencies>
+				<dependency>
+					<groupId>${project.groupId}</groupId>
+					<artifactId>shapechange-ea</artifactId>
+					<version>${project.version}</version>
+				</dependency>
+			</dependencies>
+			<build>
+				<resources>
+					<resource>
+						<directory>../shapechange-ea/src/main/resources</directory>
+						<filtering>true</filtering>
+						<targetPath>${project.basedir}/sc-resources</targetPath>
+						<includes>
+							<include>**/*</include>
+						</includes>
+						<excludes>
+							<exclude>*.properties</exclude>
+						</excludes>
+					</resource>
+				</resources>
+			</build>
+		</profile>
+	</profiles>
+
 </project>

--- a/shapechange-app/src/test/java/de/interactive_instruments/shapechange/app/BasicTest.java
+++ b/shapechange-app/src/test/java/de/interactive_instruments/shapechange/app/BasicTest.java
@@ -90,7 +90,6 @@ import de.interactive_instruments.shapechange.core.ShapeChangeResult;
 import de.interactive_instruments.shapechange.core.util.ExternalCallException;
 import de.interactive_instruments.shapechange.core.util.ExternalCallUtil;
 import de.interactive_instruments.shapechange.core.util.ZipHandler;
-import de.interactive_instruments.shapechange.ea.util.EAModelDiff;
 
 /**
  * Basic unit test for ShapeChange
@@ -642,6 +641,9 @@ public abstract class BasicTest {
 	}
     }
 
+    /** EA repository comparison helper, resolved reflectively; see similarEaRepo. */
+    private static final String EA_MODEL_DIFF_CLASSNAME = "de.interactive_instruments.shapechange.ea.util.EAModelDiff";
+
     private void similarEaRepo(String fileName, String referenceFileName) {
 
 	try {
@@ -656,12 +658,28 @@ public abstract class BasicTest {
 		fail("Reference file " + referenceFile.getAbsolutePath() + " does not exist.");
 	    }
 
-	    EAModelDiff differ = new EAModelDiff();
+	    /*
+	     * Loaded by name, exactly as DefaultModelProvider loads EA model readers, so that
+	     * these test sources compile and run without the shapechange-ea module on the
+	     * classpath. Only .qea comparisons need it; every other assertion in this class is
+	     * EA-independent.
+	     */
+	    Object differ;
+	    try {
+		differ = Class.forName(EA_MODEL_DIFF_CLASSNAME).getConstructor().newInstance();
+	    } catch (ClassNotFoundException e) {
+		fail("Comparing EA repositories requires the shapechange-ea module, which is not on"
+			+ " the classpath. Build with EA support (omit -DskipEa) to run this test."
+			+ " Result file: " + fileName);
+		return;
+	    }
 
-	    boolean similar = differ.similar(file, referenceFile);
+	    boolean similar = (Boolean) differ.getClass().getMethod("similar", File.class, File.class)
+		    .invoke(differ, file, referenceFile);
+	    String diffDetails = (String) differ.getClass().getMethod("getDiffDetails").invoke(differ);
 
 	    assertTrue(similar, "EA repository output differs from reference result. Result file: " + fileName
-		    + " - Reference file: " + referenceFileName + ". Details:\n" + differ.getDiffDetails());
+		    + " - Reference file: " + referenceFileName + ". Details:\n" + diffDetails);
 
 	} catch (Exception e) {
 	    fail("Exception while comparing EA repository '" + fileName + "' to reference file '" + referenceFileName


### PR DESCRIPTION
## Problem

`shapechange-app` declares a compile-scope dependency on `shapechange-ea`, which compiles
against `org.sparx:eaapi`. That artifact ships inside an Enterprise Architect installation
and is on no public repository, so **a machine or CI runner without EA cannot build the app
module at all**:

```
Could not resolve dependencies for project net.shapechange:shapechange-ea:jar:4.1.0-SNAPSHOT
dependency: org.sparx:eaapi:jar:17.0.1704 (compile)
Could not find artifact org.sparx:eaapi:jar:17.0.1704 in central
```

This blocks contributors and CI for input types that have nothing to do with EA — SCXML in
particular, which the `-DupdateOrCreateScxmlResources=true` mechanism exists to enable. It
also means the integration tests cannot be run at all without an EA licence, including
`OntologyTest`, whose SCXML resources were added precisely so that they run without EA.

## Why the code does not need it

The architecture already treats EA as pluggable. `DefaultModelProvider` resolves the model
reader **by class name**:

```java
} else if (modelTypeIn.equalsIgnoreCase("ea7")) {
    modelType = "de.interactive_instruments.shapechange.ea.model.EADocument";
...
theClass = Class.forName(modelType);
```

`SqlDdl` does the same for `DatabaseModelWriterEA`. Neither `shapechange-core` nor
`shapechange-app` holds a compile-time reference to any EA type — `shapechange-app` is a
single source file (`Main.java`) with no `org.sparx` import.

## Change

- **Root POM** — `shapechange-ea` moves into an `ea` profile, activated by the *absence* of
  the `skipEa` property, so the default reactor is unchanged.
- **`shapechange-app/pom.xml`** — the `shapechange-ea` dependency and the EA-only resource
  copy move into the same profile.
- **`BasicTest`** — the single EA type in the test sources (`EAModelDiff`, used by the private
  `similarEaRepo` helper for `.qea` comparisons) is resolved by class name, mirroring the main
  code. Without the module those comparisons fail with a message naming the cause, instead of
  the whole test tree failing to compile.

`mvn -DskipEa …` produces a build supporting every non-EA input type (SCXML, XMI, GCSR);
selecting `inputModelType=EA7` there fails at model load, where the lookup happens.

## Verification

Ubuntu 24.04 (WSL2), OpenJDK 21.0.11, Maven 3.9.16 — run **both** with Enterprise Architect 17
installed (`eaapi.jar` registered via `install:install-file`) and without it:

| Check | Default (EA) | `-DskipEa` |
|---|---|---|
| Reactor | 4 modules, incl. `shapechange-ea` — unchanged | `ShapeChange`, `shapechange-core`, `shapechange-app` |
| `mvn install` | SUCCESS (all three modules) | SUCCESS |
| `OntologyTest#testQualifiedCardinalityRestrictions` | 1 run, 0 failures | 1 run, 0 failures |
| Full suite | 255 run, 14 failures, 78 errors, 34 skipped | **identical: 255 / 14 / 78 / 34** |

Identical full-suite numbers on both paths: **this change alters no test outcome**.

### Accounting for the failures in the full run

Neither path is green on this machine, and none of it relates to this change:

| Cause | Count | Evidence |
|---|---|---|
| The unconditional Saxon exclusion in `shapechange-app`'s surefire config (`classpathDependencyExcludes` → `net.sf.saxon:Saxon-HE`) | 78 errors + 12 failures | With that exclusion lifted: `CodelistsTest` 3/3, `FeatureCatalogueTest` 16/16, `OutputProcessingTest` 2/2 pass |
| External `sqldiff` binary absent | 2 failures | `Cannot run program "sqldiff"` in the GeoPackage tests |
| This change | 0 | Identical counts with and without EA |

The 34 skipped tests are the same classes on both paths, the EA-backed ones among them
(`TaggedValueEaInputTransformerTest`, `SQLDatabaseModelTest`, `UmlModelTest`,
`ArcGISWorkspaceTest`): EA's native COM layer is not reachable from a Linux JVM, so they skip
whether or not the module is built. A run on Windows with EA should confirm they still execute
there — that is the one check I could not perform.

## Note, not addressed here

The Saxon exclusion above makes every XSLT-producing target fail under `mvn test`, with or
without EA. That looks worth a separate issue; deliberately untouched in this PR.
